### PR TITLE
Fix Fresnel calculation

### DIFF
--- a/refl1d/fresnel.py
+++ b/refl1d/fresnel.py
@@ -40,7 +40,7 @@ class Fresnel:
         rho_Qm = 1e-6*((self.Vrho-self.rho) + 1j*self.Virho)
         #print "fresnel",rho_Qp.shape,rho_Qm.shape,Q.shape
 
-        rho = choose(Q<0, (rho_Qm,rho_Qp))
+        rho = choose(Q<0, (rho_Qp,rho_Qm))
         kz = abs(Q)/2
         f = sqrt(kz**2 - 4*pi*rho)  # fresnel coefficient
 
@@ -71,8 +71,8 @@ def test():
     fresnel = Fresnel(rho=rho, irho=irho, Vrho=Vrho, Virho=Virho, sigma=sigma)
 
     Mw = [0,0]
-    Mrho = [[rho,Vrho]]
-    Mirho = [[irho,Virho]]
+    Mrho = [[Vrho,rho]]
+    Mirho = [[Virho,irho]]
     Msigma = [sigma]
 
     Q = numpy.linspace(-0.1,0.1,11,'d')


### PR DESCRIPTION
I have been concerned for a while that the plots produced when viewing data as "Fresnel" and "log Fresnel" deviated suspiciously far from 1. In trying to reproduce the plot for publication, I realized that the calculation was likely reversed, since the critical angle/wavevector 4*pi*rho was coming out negative. Then I noticed that the documentation of ables.refl doesn't match the usage in fresnel.test, i.e. incident medium should be the first item. That is to say, the test has been wrong the whole time.

If you check my work and decide I'm correct on this, perhaps we could also add some documentation to Fresnel.reflectivity to clear up what exactly are rho_Qm, rho_Qp.