### PR TITLE
optimize slab building when step_interfaces=True

### DIFF
--- a/refl1d/profile.py
+++ b/refl1d/profile.py
@@ -62,6 +62,8 @@ using one energy so we only show the first column.
 import numpy
 from numpy import inf, nan, isnan
 from scipy.special import erf
+from itertools import izip
+sqrt2=numpy.sqrt(2.0)
 
 class Microslabs(object):
     """
@@ -575,30 +577,47 @@ def build_profile(z, thickness, roughness, value):
     # TODO: Make sure it works even when z is wider than the range of offsets.
     if idx[-1] < len(z):
         idx[-1] = len(z)
-
-    # compute the results
+        
     result = numpy.empty_like(z)
-    for i,mvalue in enumerate(value):
+    lenval=len(value)
+    if lenval >= 30:
+        # If there are enough layers (30 on my system), quickly assign a basic profile.
+        # This prevents a lot of adding and multiplying of zeros for splines, etc.
+        # TODO: Ideally, this would be a pure numpy operation, somehow.
+        for start,stop,mvalue in izip(idx,idx[1:],value):
+            result[start:stop]=mvalue
+            
+        # Then go back to any rough layers and blend properly.
+        rough_layers = roughness.nonzero()[0] # nonzero returns a tuple of arrays
+        
+        # Now make an iterable over rough layers and the immediately above,
+        # taking care not to repeat any.
+        layer_iterator = set((rough_layers).tolist()+(rough_layers+1).tolist())
+        
+    else:
+        # Otherwise, there aren't enough layers to make that optimization worthwhile.
+        layer_iterator = xrange(lenval)
+    
+    for i in layer_iterator:
         zo = z[idx[i]:idx[i+1]]
+        
         if i==0:
             lsigma = lvalue = lblend = 0
         else:
             lsigma = roughness[i-1]
             lvalue = value[i-1]
             lblend = blend(zo-offset[i],lsigma)
-        if i >= len(value)-1:
+        
+        if i >= lenval-1:
             rsigma = rvalue = rblend = 0
         else:
             rsigma = roughness[i]
             rvalue = value[i+1]
             rblend = blend(offset[i+1]-zo,rsigma)
-        #print "zo",i,zo
-        #print "lblend",lsigma,lblend
-        #print "rblend",rsigma,rblend
+            
         mblend = 1 - (lblend+rblend)
-        result[idx[i]:idx[i+1]] = mvalue*mblend + lvalue*lblend + rvalue*rblend
-        #result[idx[i]:idx[i+1]] = rvalue*rblend
-
+        result[idx[i]:idx[i+1]] = value[i]*mblend + lvalue*lblend + rvalue*rblend
+        
     return result
 
 def blend(z, rough):
@@ -609,6 +628,6 @@ def blend(z, rough):
     profile you expect to find in the current profile at depth z.
     """
     if rough <= 0.0:
-        return numpy.where(numpy.greater(z, 0), 0.0, 1.0)
+        return z <= 0.0 # True/False behave as 1/0 for float * and +
     else:
-        return 0.5*( 1.0 - erf( z/( rough*numpy.sqrt(2.0) ) ) )
+        return 0.5*( 1.0 - erf( z/( rough*sqrt2 ) ) )


### PR DESCRIPTION
This patch improves the speed of any model that includes a microslabbed profile when the parameter step_interfaces is set to True during construction of the `Experiment` instance. Previously the computation was dominated by the `build_profile` function, rather than the reflectivity amplitude. I have observed speedup factors of 10-100 depending on the number of microslabs. A few things to note:

- This patch has no effect on any fits where `step_interfaces=False`. `build_profile` is simply not called except for plotting purposes.
- This patch does not change the calculation for any rough slabs. The blend function is simplified but the numerical result is the same.
- The patch adds an extra O(`len(thickness)`) calculation (with a small prefactor) to the beginning in exchange for reducing the rest of the calculation to O(`len(rough_layers)`)
- The patch does not add substantial time when `len(thickness)==len(rough_layers)`... about 1% +- 1%
- The quick, no-roughness profile one-liner is a bit inscrutable, but the intermediate commit shows a pure python version of the idea. 

This change was necessary to run my `EndTetheredPolymer` based fits for publication in a reasonable amount of time.