### PR TITLE
MAINT: add gitattributes to enforce line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.py text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+*.cpp text eol=lf
+*.rst text eol=lf


### PR DESCRIPTION
Just wondering if it's a good idea to make sure that the line endings for files are enforced to be linefeed.