### PR TITLE
Add option for simulate data

### DIFF
--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -280,6 +280,9 @@ class Probe(object):
 
         if noise is None:
             pass # use existing noise
+        elif isinstance(noise, (list, tuple, numpy.ndarray)) and len(noise) == len(theory):
+            self.dR = numpy.asarray(noise)
+            self.dR[self.dR==0] = 1e-11
         else:
             self.dR = 0.01*noise*self.Ro
             self.dR[self.dR==0] = 1e-11

--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -1371,9 +1371,11 @@ class PolarizedNeutronProbe(object):
     restore_data.__doc__ = Probe.restore_data.__doc__
 
     def simulate_data(self, theory, noise=2):
-        for p, th in zip(self.xs, theory):
-            if p is not None:
-                p.simulate_data(theory=th, noise=noise)
+        if numpy.isscalar(noise):
+            noise = [noise]*4
+        for data_k, theory_k, noise_k in zip(self.xs, theory, noise):
+            if data_k is not None:
+                data_k.simulate_data(theory=theory_k, noise=noise_k)
     simulate_data.__doc__ = Probe.simulate_data.__doc__
 
     def _check(self):

--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -279,12 +279,11 @@ class Probe(object):
             return
 
         if noise is None:
-            pass # use existing noise
-        elif isinstance(noise, (list, tuple, numpy.ndarray)) and len(noise) == len(theory):
-            self.dR = numpy.asarray(noise)
-            self.dR[self.dR==0] = 1e-11
+            pass
         else:
-            self.dR = 0.01*noise*self.Ro
+            self.dR = numpy.asarray(noise)
+            if len(self.dR.shape) == 0:  # noise is a scalar
+                self.dR = 0.01 * noise * self.Ro
             self.dR[self.dR==0] = 1e-11
 
         # Add noise to the theory function
@@ -868,10 +867,16 @@ class ProbeSet(Probe):
     restore_data.__doc__ = Probe.restore_data.__doc__
 
     def simulate_data(self, theory, noise=2):
+        """
+            Simulate data, allowing for noise to be a dR array for each Q point.
+        """
         Q, R = theory
+        dR = numpy.asarray(noise)
         offset = 0
         for p in self.probes:
             n = len(p.Q)
+            if len(self.dR.shape) > 0:
+                noise = dR[offset:offset+n]
             p.simulate_data(theory=(Q[offset:offset+n], R[offset:offset+n]),
                             noise=noise)
             offset += n


### PR DESCRIPTION
There was a request to add more realistic errors to ```Experiment.simulate_data(noise)```, which calls ```Probe.simulate_data(theory, noise)```.

At the moment, ```noise``` is just ```dR/R``` in percents. For cases where a full ```R(q)``` curve is made of a number of smaller ```q```-range pieces acquired separately (as we have on TOF reflectometers), providing ```dR/R``` is insufficient because the statistics will vary as a function of ```q```.

The suggested change allows the ```noise``` parameter to be an array of the same length as the ```theory``` parameter.
