### PR TITLE
update total thickness parameter to be a regular parameter instead of…

### DIFF
--- a/refl1d/model.py
+++ b/refl1d/model.py
@@ -606,7 +606,7 @@ class Repeat(Layer):
         pars = {
             'stack': self.stack.parameters(),
             'repeat': self.repeat,
-            'thickness': self._thickness,
+            'thickness': self.thickness,
             'interface': self.interface,
         }
         if self.magnetism:


### PR DESCRIPTION
… Function parameter

The implementation of this standard parameter (present in nearly every model) as a Function parameter makes it hard to serialize models.

Refactor to a simple sum of thickness parameters of all layers. (also is a parameter)

The thickness property of multilayers is also altered in this way, changing the existing behavior where multilayer.thickness -> float instead of mutlilayer.thickness -> Parameter 
