### PR TITLE
Theta offset fix

### DIFF
--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -1743,7 +1743,6 @@ class PolarizedNeutronProbe(object):
             and len(set(self._theta_offsets)) == 1:
             # offset was shared, and is shared, but value changed
             Q = TL2Q(T=self.T + shared_offset, L=self.L)
-            self.calc_T = self.T + shared_offset
             self.calc_Qo = Q
         else:
             # unshared offsets changed, or union has not been calculated before

--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -1562,7 +1562,7 @@ def measurement_union(xs):
     TL = set()
     for x in xs:
         if x is not None:
-            TL |= set(zip(x.T, x.dT, x.L, x.dL))
+            TL |= set(zip(x.T+x.theta_offset.value, x.dT, x.L, x.dL))
     T, dT, L, dL = zip(*[item for item in TL])
     T, dT, L, dL = [np.asarray(v) for v in (T, dT, L, dL)]
 
@@ -1730,6 +1730,10 @@ class PolarizedNeutronProbe(object):
 
     @property
     def calc_Q(self):
+        #print('calculating calc_Q...')
+        self.T, self.dT, self.L, self.dL, self.Q, self.dQ \
+            = measurement_union(self.xs)
+        self._set_calc(self.T, self.L)
         return self.calc_Qo
 
     def _set_calc(self, T, L):


### PR DESCRIPTION
This fix should address the Q-range for PolarizedNeutronProbe not matching the Q-range for the cross-sections in the Probe, when a non-zero theta_offset is present in one of the cross-sections (#114)

Uses a the cached self.calc_Qo if the theta_offset values in the cross-sections do not change.
If all the theta_offset values are the same, it does a minimal calculation to update Q (this is a common situation)
If all the theta_offset values are not all the same, and they change, a full calculation of the probe Q the (measurement_union(xs)) is called.