### PR TITLE
FIX: Change errors.py calc_errors() to produce a smooth magnetic profile

### DIFF
--- a/refl1d/errors.py
+++ b/refl1d/errors.py
@@ -188,7 +188,7 @@ def calc_errors(problem, points):
             slabs_i = [L.thickness.value for L in m.sample[1:-1]]
             slabs[m].append(np.array(slabs_i))
             if m.ismagnetic:
-                z, rho, irho, rhoM, thetaM = m.magnetic_step_profile()
+                z, rho, irho, rhoM, thetaM = m.magnetic_smooth_profile()
                 profiles[m].append((z+0, rho+0, irho+0, rhoM+0, thetaM+0))
             else:
                 z, rho, irho = m.smooth_profile()


### PR DESCRIPTION
Currently the contours generated for magnetic profiles for the non-sliced samples are producing a step profile. Given the fact that we are already using smooth_profile() for non-magnetic profiles, we should change this to be consistent.