### PR TITLE
Serialize stdlib dataclasses

### DIFF
--- a/extra/build_conda_packed.ps1
+++ b/extra/build_conda_packed.ps1
@@ -35,3 +35,4 @@ $version=$(& "$envdir\python.exe" -c "import refl1d; print(refl1d.__version__)")
 cd $tmpdir
 Rename-Item "$DIRNAME" "$DIRNAME-$version"
 tar -czf "refl1d-webview-Windows-x86_64.tar.gz" "$DIRNAME-$version"
+Compress-Archive -Path "$DIRNAME-$version" -DestinationPath "refl1d-webview-Windows-x86_64.zip"

--- a/extra/build_conda_packed_jupyter.sh
+++ b/extra/build_conda_packed_jupyter.sh
@@ -36,5 +36,10 @@ $envdir/bin/python -m pip install --no-compile -r https://raw.githubusercontent.
 version=$($envdir/bin/python -c "import refl1d; print(refl1d.__version__)")
 mv "$tmpdir/$DIRNAME" "$tmpdir/$DIRNAME-$version"
 
+case $OSTYPE in 
+  # darwin*) cd $tmpdir && hdiutil create -srcfolder  "$DIRNAME-$version" -volname "Refl1D_Jupyter" "$WORKING_DIRECTORY/Refl1D_Jupyter.dmg" ;; 
+  darwin*) pkgbuild --root $tmpdir --identifier org.reflectometry.refl1d-webview-jupyter --version $version --ownership preserve --install-location /Applications refl1d-webview-jupyter-$(uname -s)-$(uname -m).pkg ;;
+esac
+
 cd $tmpdir && tar -czf "$WORKING_DIRECTORY/refl1d-webview-jupyter-$version-$(uname -s)-$(uname -m).tar.gz" "$DIRNAME-$version"
 rm -rf $tmpdir

--- a/extra/gen_schema_v2.py
+++ b/extra/gen_schema_v2.py
@@ -1,0 +1,31 @@
+from pydantic_core import core_schema
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from pydantic import TypeAdapter, ConfigDict
+
+from bumps.parameter import *
+from bumps.util import NumpyArray
+NDArray = NumpyArray
+
+from refl1d.names import *
+from refl1d.model import *
+from refl1d.fitproblem import FitProblem
+
+class BumpsGenerateJsonSchema(GenerateJsonSchema):
+    def dataclass_schema(self, schema: core_schema.DataclassSchema) -> JsonSchemaValue:
+        cls = schema['cls']
+        fqn = f"{cls.__module__}.{cls.__name__}"
+        print("fqn: ", fqn)
+        # filter attrs with leading underscore name (same behavior as in v1)
+        schema['schema']['fields'] = [f for f in schema['schema']['fields'] if not f['name'].startswith("_")]
+        json_schema = super().dataclass_schema(schema)
+        properties = json_schema.get('properties', {})
+        for prop, value in properties.items():
+            value.pop('title', None)
+        properties.setdefault('type', {'enum': [fqn]})
+        return json_schema
+
+TA = TypeAdapter(FitProblem)
+schema = TA.json_schema(schema_generator=BumpsGenerateJsonSchema)
+
+import json
+print(json.dumps(schema, indent=2))

--- a/refl1d/experiment.py
+++ b/refl1d/experiment.py
@@ -9,18 +9,19 @@ to create a fittable reflectometry model.
 """
 from __future__ import division, print_function
 
+from dataclasses import dataclass, field
 import sys
 import os
 from math import pi, log10, floor
 import traceback
 import json
+from typing import Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 from warnings import warn
 
 import numpy as np
 from bumps import parameter
 from bumps.parameter import Parameter, Constraint, tag_all
 from bumps.fitproblem import Fitness
-from bumps.util import field, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 
 from . import material, profile
 from . import __version__
@@ -306,7 +307,7 @@ class ExperimentBase:
                             theory=theory)
 
 
-@schema(init=False)
+@dataclass(init=False)
 class Experiment(ExperimentBase):
     """
     Theory calculator.  Associates sample with data, Sample plus data.
@@ -646,7 +647,7 @@ class Experiment(ExperimentBase):
 
 assert isinstance(Experiment, Fitness)
 
-@schema(init=False)
+@dataclass(init=False)
 class MixedExperiment(ExperimentBase):
     """
     Support composite sample reflectivity measurements.

--- a/refl1d/fitproblem.py
+++ b/refl1d/fitproblem.py
@@ -1,15 +1,14 @@
-from bumps.util import schema, List
-from bumps.fitproblem import FitProblem as _FitProblem, FitProblemSchema as _FitProblemSchema
+from dataclasses import dataclass
+from typing import List
+from bumps.fitproblem import FitProblem as _FitProblem
 from .experiment import Experiment
 
-# @schema(eq=False, init=False)
+# @dataclass(init=False)
 # class BaseFitProblem(_BaseFitProblem):
 #     fitness: Experiment
 
-@schema(classname="FitProblem", eq=False, init=False)
-class FitProblemSchema(_FitProblemSchema):
+@dataclass(init=False)
+class FitProblem(_FitProblem):
     __doc__ =  _FitProblem.__doc__.replace("Fitness", "Experiment")
     models: List[Experiment]
 
-class FitProblem(_FitProblem, FitProblemSchema):
-    ...

--- a/refl1d/magnetism.py
+++ b/refl1d/magnetism.py
@@ -39,6 +39,7 @@ and anchoring them to the structure.
 """
 from __future__ import print_function
 
+from dataclasses import dataclass
 import numpy as np
 from numpy import inf
 from bumps.parameter import Parameter, flatten, to_dict
@@ -48,7 +49,7 @@ from bumps.util import field, schema, Optional, Any, Union, Dict, Callable, Lite
 from .reflectivity import BASE_GUIDE_ANGLE as DEFAULT_THETA_M
 
 
-@schema()
+@dataclass
 class BaseMagnetism:
     """
     Magnetic properties of the layer.
@@ -125,7 +126,7 @@ class BaseMagnetism:
             self.name = name
 
 
-@schema(init=False)
+@dataclass(init=False)
 class Magnetism(BaseMagnetism):
     """
     Region of constant magnetism.
@@ -180,7 +181,7 @@ class Magnetism(BaseMagnetism):
                 %(self.rhoM.value, self.thetaM.value))
 
 
-@schema(init=False)
+@dataclass(init=False)
 class MagnetismStack(BaseMagnetism):
     """
     Magnetic slabs within a magnetic layer.
@@ -294,7 +295,7 @@ class MagnetismStack(BaseMagnetism):
         return "MagnetismStack"
 
 
-@schema(init=False)
+@dataclass(init=False)
 class MagnetismTwist(BaseMagnetism):
     """
     Linear change in magnetism throughout layer.
@@ -355,7 +356,7 @@ class MagnetismTwist(BaseMagnetism):
         return "MagneticTwist"
 
 
-@schema(init=False)
+@dataclass(init=False)
 class FreeMagnetism(BaseMagnetism):
     """
     Spline change in magnetism throughout layer.

--- a/refl1d/magnetism.py
+++ b/refl1d/magnetism.py
@@ -39,12 +39,12 @@ and anchoring them to the structure.
 """
 from __future__ import print_function
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import numpy as np
 from numpy import inf
 from bumps.parameter import Parameter, flatten, to_dict
 from bumps.mono import monospline
-from bumps.util import field, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
+from bumps.util import Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 
 from .reflectivity import BASE_GUIDE_ANGLE as DEFAULT_THETA_M
 

--- a/refl1d/material.py
+++ b/refl1d/material.py
@@ -42,12 +42,14 @@ the end, sld is just the returned scattering factors times density.
 """
 __all__ = ['Material', 'Mixture', 'SLD', 'Vacuum', 'Scatterer', 'ProbeCache', 'BulkDensityMaterial', 'NaturalDensityMaterial', 'NumberDensityMaterial', 'RelativeDensityMaterial', 'CellVolumeMaterial']
 
+from dataclasses import dataclass, field
+from typing import Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
+
 import numpy as np
 from numpy import inf, NaN
 import periodictable
 from periodictable.constants import avogadro_number
 from bumps.parameter import Expression, Parameter, to_dict #, PARAMETER_TYPES, UnaryExpression
-from bumps.util import field, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 from periodictable.formulas import Formula as BaseFormula
 
 
@@ -93,7 +95,7 @@ class Scatterer:
 
 
 # ============================ No scatterer =============================
-@schema(init=False)
+@dataclass(init=False)
 class Vacuum(Scatterer):
     """
     Empty layer (all sld = 0)
@@ -118,7 +120,7 @@ class Vacuum(Scatterer):
 
 
 # ============================ Unknown scatterer ========================
-@schema(init=False)
+@dataclass(init=False)
 class SLD(Scatterer):
     r"""
     Unknown composition.
@@ -234,7 +236,7 @@ def Material(
         raise ValueError(f'unknown value "{fitby}" of fitby: should be one of ["bulk_density", "natural_density", "relative_density", "number_density", "cell_volume"]')
 
 
-@schema(init=False)
+@dataclass(init=False)
 class BulkDensityMaterial(BaseMaterial):
     """
     A solid block of material, described by its bulk density
@@ -266,7 +268,7 @@ class BulkDensityMaterial(BaseMaterial):
         return dict(density=self.density)
 
 
-@schema()
+@dataclass(init=False)
 class NaturalDensityMaterial(BaseMaterial):
     """
     A solid block of material, described by its natural density
@@ -299,7 +301,7 @@ class NaturalDensityMaterial(BaseMaterial):
         return dict(density=self.density, natural_density=self.natural_density)
 
 
-@schema()
+@dataclass(init=False)
 class NumberDensityMaterial(BaseMaterial):
     """
     A solid block of material, described by its number density
@@ -341,7 +343,7 @@ class NumberDensityMaterial(BaseMaterial):
         return dict(density=self.density, number_density=self.number_density)
 
 
-@schema()
+@dataclass(init=False)
 class RelativeDensityMaterial(BaseMaterial):
     """
     A solid block of material, described by its relative density
@@ -381,7 +383,7 @@ class RelativeDensityMaterial(BaseMaterial):
         return dict(density=self.density, relative_density=self.relative_density)
 
 
-@schema()
+@dataclass(init=False)
 class CellVolumeMaterial(BaseMaterial):
     """
     A solid block of material, described by the volume of one unit cell

--- a/refl1d/model.py
+++ b/refl1d/model.py
@@ -26,13 +26,9 @@ scattering density may vary with depth in the layer.
 __all__ = ['Repeat', 'Slab', 'Stack', 'Layer']
 
 from copy import copy, deepcopy
+from dataclasses import dataclass, field
 import json
-
-try:
-    from typing import Union, List, Optional, Any, Literal
-except ImportError:
-    from typing import Union, List, Optional, Any
-    from typing_extensions import Literal
+from typing import Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 
 import numpy as np
 from numpy import (inf, nan, pi, sin, cos, tan, sqrt, exp, log, log10,
@@ -44,12 +40,11 @@ import periodictable.nsf as nsf
 from bumps.parameter import (
     #BaseParameter as BasePar,
     Calculation, Parameter, to_dict)
-from bumps.util import field, field_desc, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 
 from . import material as mat
 from .magnetism import BaseMagnetism
 
-#@schema(init=False)
+#@dataclass(init=False)
 class Layer: # Abstract base class
     """
     Component of a material description.
@@ -205,7 +200,7 @@ def _parcopy(p, v):
     return p
 
 
-@schema(init=False)
+@dataclass(init=False)
 class Slab(Layer):
     """
     A block of material.
@@ -262,22 +257,8 @@ class Slab(Layer):
         })
 
 
-@schema(classname="Stack")
-class StackSchema:
-    """
-    Reflectometry layer stack
-
-    A reflectometry sample is defined by a stack of layers. Each layer
-    has an interface describing how the top of the layer interacts with
-    the bottom of the overlaying layer. The stack may contain Slab or Repeats.
-    """
-    name: str
-    interface: Literal[None]
-    layers: List[Union['Slab', 'Repeat']]
-    thickness: Parameter = field_desc("always equals the sum of the layer thicknesses")
-
-
-class Stack(Layer, StackSchema):
+@dataclass(init=False)
+class Stack(Layer):
     """
     Reflectometry layer stack
 
@@ -285,6 +266,10 @@ class Stack(Layer, StackSchema):
     has an interface describing how the top of the layer interacts with
     the bottom of the overlaying layer. The stack may contain
     """
+    name: str
+    interface: Literal[None]
+    layers: List[Union['Slab', 'Repeat']]
+    thickness: Parameter = field(metadata = {"description": "always equals the sum of the layer thicknesses"})
 
     def __init__(self, base=None, layers=None, name="Stack", interface=None, thickness: Optional[Union[Parameter, float]]=None):
         self.name = name
@@ -628,7 +613,7 @@ def _check_layer(el):
         raise TypeError("Can only stack materials and layers, not %s"%el)
 
 
-@schema(init=False)
+@dataclass(init=False)
 class Repeat(Layer):
     """
     Repeat a layer or stack.

--- a/refl1d/mono.py
+++ b/refl1d/mono.py
@@ -3,10 +3,11 @@ Monotonic spline modeling for free interfaces
 """
 from __future__ import division, with_statement
 
+from dataclasses import dataclass, field
+from typing import Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 import numpy as np
 from numpy import (diff, hstack, sqrt, searchsorted, asarray, cumsum,
                    inf, nonzero, linspace, sort, isnan, clip)
-from bumps.util import field, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 from bumps.parameter import Parameter as Par, Function as ParFunction, to_dict, Constant
 from bumps.mono import monospline, count_inflections
 
@@ -102,7 +103,7 @@ def inflections(dx, dy):
     y = hstack((0, cumsum(dy)))
     return count_inflections(x, y)
 
-@schema()
+@dataclass(init=False)
 class FreeInterface(Layer):
     """
     A freeform section of the sample modeled with monotonic splines.

--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -41,6 +41,7 @@ from __future__ import with_statement, division, print_function
 import os
 import json
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 
 import numpy as np
@@ -50,7 +51,7 @@ import numpy.random
 import numpy.fft
 from typing import NamedTuple, Optional, Any, Sequence, Union, TYPE_CHECKING
 
-from bumps.util import field, field_desc, schema, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
+from bumps.util import field, field_desc, Optional, Any, Union, Dict, Callable, Literal, Tuple, List, Literal
 
 from periodictable import nsf, xsf
 from bumps.parameter import Parameter, to_dict, Constant
@@ -587,7 +588,7 @@ class BaseProbe:
         else:
             return suffix+" "+gloss if gloss else None
 
-@schema(init=False, eq=False)
+@dataclass(init=False)
 class Probe(BaseProbe):
     r"""
     Defines the incident beam used to study the material.
@@ -1630,7 +1631,7 @@ def _data_as_probe(entry, json_header_encoding, probe_args, T, L, dT, dL, dR, FW
     return probe
 
 
-@schema()
+@dataclass(init=False)
 class QProbe(BaseProbe):
     """
     A pure Q, R probe
@@ -1761,7 +1762,7 @@ def Qmeasurement_union(xs):
 
 optional_xs = Union[NeutronProbe, Literal[None]]
 
-@schema(init=False)
+@dataclass(init=False)
 class PolarizedNeutronProbe:
     """
     Polarized neutron probe
@@ -2154,7 +2155,7 @@ def _interpolate_Q(Q, dQ, n):
     return Q, dQ
 
 
-@schema(init=False)
+@dataclass(init=False)
 class PolarizedQProbe(PolarizedNeutronProbe):
     polarized = True
     def __init__(self, xs=None, name=None, Aguide=BASE_GUIDE_ANGLE, H=0):


### PR DESCRIPTION
I don't think we need a custom schema decorator.  We added keyword arguments "exclude" and "include" to the schema decorator, but they never ended up getting used, and there are other ways to solve that problem if it ever comes up.

Also, at some point stdlib dataclasses started supporting descriptor-based attributes.  This removed the need for the complicated structure like 
```python
@schema(classname="Parameter")
class ParameterSchema:
    ...

class Parameter(ParameterSchema):
    ...
```
 Need to check when that happened, to ensure compatibility.