### PR TITLE
Custom Plot API

### DIFF
--- a/refl1d/webview/client/src/components/CustomPlot.vue
+++ b/refl1d/webview/client/src/components/CustomPlot.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+/// <reference types="@types/plotly.js" />
+import { ref, shallowRef } from 'vue';
+import * as Plotly from 'plotly.js/lib/core';
+import type { AsyncSocket } from 'bumps-webview-client/src/asyncSocket.ts';
+import { setupDrawLoop } from 'bumps-webview-client/src/setupDrawLoop';
+import { COLORS } from '../colors.mjs';
+import { configWithSVGDownloadButton } from 'bumps-webview-client/src/plotly_extras.mjs';
+
+const title = "Custom";
+const plot_div = ref<HTMLDivElement | null>(null);
+const plot_data = shallowRef<Partial<Plotly.Data>>({});
+const plot_layout = shallowRef<Partial<Plotly.Layout>>({});
+
+const props = defineProps<{
+  socket: AsyncSocket,
+}>();
+
+setupDrawLoop('updated_parameters', props.socket, fetch_and_draw);
+
+async function fetch_and_draw() {
+  //const payload = await props.socket.asyncEmit('hello_world', 'linear') as {plotdata: Partial<Plotly.PlotData>};
+  const payload = await props.socket.asyncEmit('get_custom_plot') as { data: Partial<Plotly.PlotData>[], layout: Partial<Plotly.Layout> };
+  let plotdata = { ...payload };
+  const { data, layout } = plotdata;
+
+  const config: Partial<Plotly.Config> = {
+    responsive: true,
+    edits: {
+      legendPosition: true
+    }, 
+    ...configWithSVGDownloadButton
+  }
+  await Plotly.react(plot_div.value as HTMLDivElement, [...data], layout, config);
+
+}
+
+</script>
+
+<template>
+  <div class="container d-flex flex-column flex-grow-1">
+    <div class="flex-grow-1" ref="plot_div" id="plot_div">
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.plot-mode {
+  width: 100%;
+}
+</style>

--- a/refl1d/webview/client/src/panels.mjs
+++ b/refl1d/webview/client/src/panels.mjs
@@ -3,12 +3,14 @@ import DataView from './components/DataView.vue';
 import ModelView from './components/ModelView.vue';
 import SimpleBuilder from './components/SimpleBuilder.vue';
 import ProfileUncertaintyView from './components/ProfileUncertaintyView.vue';
+import CustomPlot from './components/CustomPlot.vue';
 
 const refl1d_panels = [
     {title: 'Reflectivity', component: DataView},
     {title: 'Profile', component: ModelView},
     {title: 'Profile Uncertainty', component: ProfileUncertaintyView},
     {title: 'Builder', component: SimpleBuilder},
+    {title: 'Custom', component: CustomPlot}
 ];
 
 const replacements = {
@@ -18,7 +20,8 @@ const replacements = {
 
 const insertions = {
     'Profile': { after: 'Summary'},
-    'Builder': { after: 'Uncertainty' }
+    'Builder': { after: 'Uncertainty' },
+    'Custom': { after: 'Builder'}
 }
 
 function replace_panel(panels, replacement_panels, replaced_title, replacement_title) {

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -58,8 +58,6 @@ async def get_profile_plots(model_specs: List[ModelSpec]):
     del fig
     return output
 
-
-
 def get_single_probe_data(theory, probe, substrate=None, surface=None, polarization=""):
     fresnel_calculator = probe.fresnel(substrate, surface)
     Q, FQ = probe.apply_beam(probe.calc_Q, fresnel_calculator(probe.calc_Q))
@@ -125,6 +123,19 @@ async def get_profile_uncertainty_plot(auto_align: bool=True, align: float=0., n
         return output
     else:
         return None
+
+@register
+async def get_custom_plot():
+    if state.problem is None or state.problem.fitProblem is None:
+        return None
+    fitProblem = state.problem.fitProblem
+    if not hasattr(fitProblem, 'custom_plot'):
+        return None
+    else:
+        fitProblem.chisq_str()
+
+    fig = fitProblem.custom_plot()
+    return to_json_compatible_dict(fig.to_dict())
 
 @register
 async def load_probe_from_file(pathlist: List[str], filename: str, model_index: int = 0):


### PR DESCRIPTION
This is a dummy custom plot API allowing responsive plots of quantities derived from the model parameters.

Basically the plot definition function is stored in a new attribute of `problem`, `problem.custom_plot`, and must output a Plotly figure that is rendered directly and responsively in the Refl1D GUI.

Future improvements could involve allowing multiple plots (say, as a dictionary, with keys corresponding to the title of each custom plot, and they can be selected using pills or tabs).

This PR is intended mainly as a conversation starter around this. A model file with data that show this in operation is attached.

[crau_popc.zip](https://github.com/user-attachments/files/15870914/crau_popc.zip)