### PR TITLE
Get version number from tag using versioningit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__/
 /*.egg-info/
 /EGG-INFO
 /.eggs
+refl1d/_version.py
 
 # Environments
 .env

--- a/doc/getting_started/contributing.rst
+++ b/doc/getting_started/contributing.rst
@@ -179,3 +179,33 @@ Build the executable using::
 
 This creates a *.dmg* file in the *dist* directory with the Refl1D app
 inside.
+
+Creating a new release
+----------------------
+
+A developer with maintainer status can tag a new release and publish a package to the `Python
+Package Index (PyPI) <https://pypi.org/project/refl1d/>`_. Refl1d uses
+`versioningit <https://versioningit.readthedocs.io/>`_ to generate the version number
+from the latest tag in the git repository.
+
+1. Update the local copy of the master branch::
+
+    # update information from all remotes
+    git fetch -p -P -t --all
+    # update local copy of master
+    git checkout master
+    git rebase origin/master
+    # check the current version number
+    versioningit
+    > 0.8.17.dev805
+
+2. Add release notes and commit to master.
+
+3. Create the new tag and push it to the remote. Pushing a tag starts the GitHub workflow job to
+publish to PyPI (defined in `.github/workflows/publish.yml
+<https://github.com/reflectometry/refl1d/blob/master/.github/workflows/publish.yml>`_)::
+
+    git tag v1.0.0
+    versioningit
+    > 1.0.0
+    git push origin --tags master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest", "pytest-cov"]
+dev = ["pre-commit", "ruff", "pytest", "pytest-cov", "versioningit"]
 full = ["wxpython", "ipython"]
 webview = ["bumps[webview]@git+https://github.com/bumps/bumps.git#egg=master"]
 
@@ -42,7 +42,7 @@ homepage = "https://refl1d.github.io"
 repository = "https://github.com/reflectometry/refl1d"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
@@ -86,3 +86,18 @@ norecursedirs = ["view", "mystic", "bin", "webview/client", "explore"]
 python_files = ["*.py"]
 python_classes = ["NoClassTestsWillMatch"]
 python_functions = ["test", "*_test", "test_*"]
+
+[tool.versioningit.vcs]
+method = "git"
+default-tag = "0.0.1"
+
+[tool.versioningit.next-version]
+method = "smallest"
+
+[tool.versioningit.format]
+distance = "{next_version}.dev{distance}"
+dirty = "{version}+d{build_date:%Y%m%d}"
+distance-dirty = "{next_version}.dev{distance}+d{build_date:%Y%m%d%H%M}"
+
+[tool.versioningit.write]
+file = "refl1d/_version.py"

--- a/refl1d/__init__.py
+++ b/refl1d/__init__.py
@@ -19,7 +19,10 @@ import os
 import sys
 from typing import Literal
 
-__version__ = "1.0.0a0"
+try:
+    from ._version import __version__  # noqa: F401
+except ImportError:
+    __version__ = "unknown"
 
 
 BACKEND_NAMES = Literal["numba", "c_ext", "python"]


### PR DESCRIPTION
This change eliminates the need for a hard coded version number, since the package version number will be generated from the git tag.

Same change done recently in bumps: https://github.com/bumps/bumps/pull/153