### PR TITLE
Docs build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,37 @@
+name: Sphinx docs to gh-pages
+
+on:
+  push:
+    branches:
+      - master
+
+  workflow_dispatch:        # Un comment line if you also want to trigger action manually
+
+jobs:
+  sphinx_docs_to_gh-pages:
+    runs-on: ubuntu-latest
+    name: Sphinx docs to gh-pages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Make conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.12"    # Python version to build the html sphinx documentation
+          # environment-file: doc/docs_env.yaml    # Path to the documentation conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Installing the library
+        shell: bash -l {0}
+        run: |
+          python -m pip install .[dev]
+      - name: Running the Sphinx to gh-pages Action
+        uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.1.0
+        with:
+          branch: master
+          dir_docs: doc
+          sphinx-apidoc-opts: '--separate -o . ../'
+          sphinx-apidoc-exclude: '../*setup* ../*.ipynb'
+          sphinx-opts: ''

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Installing the library
         shell: bash -l {0}
         run: |
-          python -m pip install .[dev]
+          python -m pip install .[dev] sphinx
       - name: Running the Sphinx to gh-pages Action
         uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.1.0
         with:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import with_statement
 import sys, os
 
 print("python %s" % sys.executable)
@@ -32,12 +31,6 @@ print("python %s" % sys.executable)
 sys.path.append(os.path.abspath("."))  # for sitedoc
 sys.path.append(os.path.abspath("_extensions"))  # for sphinx extensions
 
-import imp
-from os.path import abspath, dirname, split as splitpath, join as joinpath
-
-run_py = joinpath(dirname(dirname(abspath(__file__))), "run.py")
-run = imp.load_source("run", run_py)
-run.prepare_environment()
 print("== path ==")
 print("\n".join(sys.path))
 print("== end path ==")


### PR DESCRIPTION
Use GitHub actions to build docs and publish to gh-pages (docs would appear at https://reflectometry.github.io/)