### PR TITLE
Monthly pre commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,6 @@ repos:
       # - id: ruff
       #   args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+
+ci:
+    autoupdate_schedule: monthly


### PR DESCRIPTION
Change schedule of pre-commit autoupdate (of tools like ruff, etc. in .pre-commit-config.yaml) to monthly instead of weekly.