### PR TITLE
Windows shell launcher

### DIFF
--- a/extra/build_conda_packed.sh
+++ b/extra/build_conda_packed.sh
@@ -34,7 +34,8 @@ tar -xzf "$ENV_NAME.tar.gz" -C "$envdir"
 case $OSTYPE in 
   darwin*) cp -r ./extra/platform_scripts/refl1d_webview.app "$pkgdir" ;
            cp -r ./extra/platform_scripts/refl1d_shell.app "$pkgdir" ;;
-  msys*) cp ./extra/platform_scripts/refl1d_webview.bat "$pkgdir" ;;
+  msys*) cp ./extra/platform_scripts/refl1d_webview.bat "$pkgdir" ;
+         cp ./extra/platform_scripts/refl1d_shell.bat "$pkgdir" ;;
   linux*) cp -r ./extra/platform_scripts/make_linux_desktop_shortcut.sh "$pkgdir" ;
           cp -r ./extra/platform_scripts/refl1d-webview "$pkgdir" ;;
 esac

--- a/extra/platform_scripts/refl1d_shell.bat
+++ b/extra/platform_scripts/refl1d_shell.bat
@@ -1,0 +1,4 @@
+@echo off
+rem start "Refl1d Environment Shell" 
+start cmd /k "%~dp0env\Scripts\activate.bat"
+


### PR DESCRIPTION
A bat file so that users can open a terminal window with the refl1d virtual environment activated, to enable simple installation of additional refl1d-related package, e.g.
```sh
pip install molgroups
```