### PR TITLE
switch to using defaults for versioningit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,13 +86,5 @@ python_functions = ["test", "*_test", "test_*"]
 method = "git"
 default-tag = "0.0.1"
 
-[tool.versioningit.next-version]
-method = "smallest"
-
-[tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
-dirty = "{version}+d{build_date:%Y%m%d}"
-distance-dirty = "{next_version}.dev{distance}+d{build_date:%Y%m%d%H%M}"
-
 [tool.versioningit.write]
 file = "refl1d/_version.py"


### PR DESCRIPTION
The settings that are currently used for `versioningit` in the `pyproject.toml` specify that the "next" version should be used when doing a wheel build or local install.

This causes the unexpected behavior that if a developer makes a change to a repository file and then does a local install to test, it automatically versions the install with the next patch version, but this conflicts with the way we are incrementing our versions (local build will get e.g. version 1.0.1 before an actual release 1.0.1 is made with a new tag, which is how `versioningit` is supposed to increment the version.

The default behavior of `versioningit` is to create local versions based on the most recent tag, which is the correct thing to do here, I think.  This PR removes our manual configuration of `versioningit` (which uses "next_version").