### PR TITLE
add flags for enabling optional persistent path from shortcuts

### DIFF
--- a/extra/platform_scripts/make_linux_desktop_shortcut.sh
+++ b/extra/platform_scripts/make_linux_desktop_shortcut.sh
@@ -14,7 +14,7 @@ script_dir=$(realpath $(dirname $0))
 echo "[Desktop Entry]
 Name=Refl1d-Webview
 Comment=Start the refl1d webview server
-Exec='$script_dir/env/bin/python' -m refl1d.webview.server
+Exec='$script_dir/env/bin/python' -m refl1d.webview.server --use_persistent_path
 Icon=$script_dir/env/share/icons/refl1d-icon.svg
 Terminal=true
 Type=Application

--- a/extra/platform_scripts/refl1d_webview.app/refl1d_webview
+++ b/extra/platform_scripts/refl1d_webview.app/refl1d_webview
@@ -5,7 +5,7 @@ on run argv
       set base_path to container of (container of (path to me)) as alias
    end tell
    set env_activate to "source " & quoted form of ((POSIX path of base_path) & "env/bin/activate") & ";"
-   set run_server_and_terminate to ( " python" & " -m" & " refl1d.webview.server;" & " exit;")
+   set run_server_and_terminate to ( " python" & " -m" & " refl1d.webview.server --use_persistent_path;" & " exit;")
    if application "Terminal" is not running then
       tell application "Terminal"
          activate

--- a/extra/platform_scripts/refl1d_webview.bat
+++ b/extra/platform_scripts/refl1d_webview.bat
@@ -1,4 +1,4 @@
 @echo off
 rem start "Refl1d Web GUI" 
 call "%~dp0env\Scripts\activate.bat"
-start "Refl1D Webview" "python.exe" "-m" "refl1d.webview.server"
+start "Refl1D Webview" "python.exe" "-m" "refl1d.webview.server" "--use_persistent_path"


### PR DESCRIPTION
Using the persistent path written to disk is now optional, but we want to enable that feature for users running the webview application from a shortcut that was added during installation of the conda-packed distribution.