### PR TITLE
Make LICENSE.txt consistent with documentation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,1 +1,21 @@
-Refl1d is in the public domain.
+Copyright 2006-2024 The Refl1D Contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/doc/getting_started/license.rst
+++ b/doc/getting_started/license.rst
@@ -4,59 +4,33 @@
 License
 *******
 
-The DANSE/Reflectometry group relies on a large body of open source
-software, and so combines the work of many authors. These works are
-released under a variety of licenses, including BSD and LGPL, and much
-of the work is in the public domain. See individual files for details.
+.. include:: ../../LICENSE.txt
 
-The combined work is released under the following license:
-
-	Copyright (c) 2006-2011, University of Maryland All rights reserved.
-
-	Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions
-	are met:
-
-	Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer. Redistributions
-	in binary form must reproduce the above copyright notice, this list of
-	conditions and the following disclaimer in the documentation and/or
-	other materials provided with the distribution. Neither the name of the
-	University of Maryland nor the names of its contributors may be used to
-	endorse or promote products derived from this software without specific
-	prior written permission.
-
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-	HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-	TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-	OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-	OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-	NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Additional pieces may be available under the GPL. When these pieces
-are used in the package, the combined work is also subject to the GPL.
 
 *******
 Credits
 *******
 
-Refl1D package was developed under DANSE project and is maintained by
-its user community.
+The Refl1D package was originally developed under DANSE project (2006-2011),
+with a transition to a period of community support in 2011 
+(primarily maintained at NIST)
 
-Please cite:
+In 2024, a new collaboration was formed with developers from
 
-        Kienzle, P.A., Krycka, J., Patel, N., & Sahin, I.
-        Refl1D (Version |release|) [Computer Software].
-        College Park, MD: University of Maryland.  Retrieved |today|.
+- the National Institute of Standards and Technology (Gaithersburg, MD, USA)
+- ISIS Neutron and Muon Source (Oxfordshire, UK)
+- Oak Ridge National Laboratory (Oak Ridge, TN, USA)
 
-Available from https://github.com/reflectometry/refl1d
+dedicated to the continued development of the package, and delivery of new
+features and capabilities to the user community.
 
 We are grateful for the existence of many fine open source packages such
 as `Pyparsing <http://pyparsing.wikispaces.com/>`_,
 `NumPy <http://numpy.scipy.org/>`_ and `Python <http://www.python.org/>`_
 without which this package would be much more difficult to write.
+
+********
+Citation
+********
+
+Please cite using this DOI: https://dx.doi.org/10.5281/zenodo.1249715

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: Public Domain",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
The license (3-clause BSD) contained in the documentation under `doc/getting_started/license.rst` was not the same as the content of `LICENSE.txt`

This PR adds the 3-clause BSD license to LICENSE.txt, and includes that file directly into the `license.rst` with an `include` statement.

Also, the `CREDITS` section is updated to include the new collaboration, and the citation is updated to use the DOI created by Zenodo.