### PR TITLE
re-enable oversampling on PolarizedQProbe

### DIFF
--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -2239,6 +2239,8 @@ class PolarizedQProbe(PolarizedNeutronProbe):
         name=None,
         Aguide=BASE_GUIDE_ANGLE,
         H=0,
+        oversampling: Optional[int] = None,
+        oversampling_seed: int = 1,
     ):
         if any([mm, mp, pm, pp]):
             if xs is not None:
@@ -2255,6 +2257,8 @@ class PolarizedQProbe(PolarizedNeutronProbe):
         self.unique_L = None
         self.Aguide = Parameter.default(Aguide, name="Aguide " + self.name, limits=[-360, 360])
         self.H = Parameter.default(H, name="H " + self.name)
+        if oversampling is not None:
+            self.oversample(oversampling, oversampling_seed)
         self.Q, self.dQ = Qmeasurement_union(self.xs)
         self.calc_Qo = self.Q
 


### PR DESCRIPTION
`refl1d.probe.PolarizedQProbe` inherits from `PolarizedNeutronProbe`, but does not handle the inherited `oversampling` or `oversampling_seed` kwargs in the init, so deserialization is currently broken.

This PR adds these argument to the `PolarizedQProbe.__init__`, and calls the base class `oversample(oversampling, oversampling_seed)` method during initialization, properly oversampling all the xs.

This fixes the bug on deserialization, and also enables users of the class to take advantage of oversampling if it helps them in their fits.