### PR TITLE
Profile uncertainty export with best

### DIFF
--- a/refl1d/webview/client/src/components/ProfileUncertaintyView.vue
+++ b/refl1d/webview/client/src/components/ProfileUncertaintyView.vue
@@ -37,8 +37,10 @@ type Payload  = {
   contour_data: {
     [model_name: string]: {
       z: number[],
-      data: { [key: string]: number[][][] },
-    }
+      data: { [key: string]: {
+        [contour_label: string]: number[],
+      }},
+    },
   },
   contours: number[],
 }
@@ -57,12 +59,10 @@ function get_csv_data() {
   for (const [model_name, model_data] of Object.entries(data)) {
     headers.push(`"${model_name} z"`);
     values.push(model_data.z);
-    Object.keys(model_data.data).forEach((key) => {
-      contours_value.forEach((c, ci) => {
-        headers.push(`"${model_name} ${key} (${c} lower)"`);
-        headers.push(`"${model_name} ${key} (${c} upper)"`);
-        values.push(model_data.data[key][ci][0]);
-        values.push(model_data.data[key][ci][1]);
+    Object.entries(model_data.data).forEach(([key, value]) => {
+      Object.entries(value).forEach(([c, v]) => {
+        headers.push(`"${model_name} ${key} ${c}"`);
+        values.push(v);
       });
     });
   }

--- a/refl1d/webview/server/profile_uncertainty.py
+++ b/refl1d/webview/server/profile_uncertainty.py
@@ -239,12 +239,13 @@ def _draw_contours(
         col=col,
         secondary_y=secondary_y,
     )
-    q = _plot_quantiles(
+    named_contours = _plot_quantiles(
         zp, fp, contours, color, alpha=None, fig=fig, row=row, col=col, legendgroup=legendgroup, secondary_y=secondary_y
     )
+    named_contours["best"] = fp[0]
     # Plot the best
     # axes.plot(zp, fp[0], '-', label=label, color=dark(color))
-    return q
+    return named_contours
 
 
 def _profile_labels(fig: "go.Figure", row: Optional[int] = None, col: Optional[int] = None, magnetic: bool = False):
@@ -366,9 +367,12 @@ def _plot_quantiles(
     """
     _, q = form_quantiles(y, contours)
 
+    output = {}
     if alpha is None:
         alpha = 2.0 / (len(q) + 1)
-    for lo, hi in q:
+    for contour, (lo, hi) in zip(contours, q):
+        output[f"{contour} percent lower"] = lo
+        output[f"{contour} percent upper"] = hi
         fig.add_scattergl(
             x=x,
             y=lo,
@@ -396,4 +400,4 @@ def _plot_quantiles(
             legendgroup=legendgroup,
             secondary_y=secondary_y,
         )
-    return q
+    return output


### PR DESCRIPTION
The best fit line was missing from the export of the profile uncertainty to CSV.

This PR adds the best fit line to the contour data sent to the client, and simplifies the handling of the contour data by labelling each contour in a dict instead of passing a nested array.