### PR TITLE
allow background parameter of Probe to be negative

### DIFF
--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -758,7 +758,7 @@ class Probe(BaseProbe):
             name = os.path.splitext(os.path.basename(filename))[0]
         qualifier = " " + name if name is not None else ""
         self.intensity = Parameter.default(intensity, name="intensity" + qualifier)
-        self.background = Parameter.default(background, name="background" + qualifier, limits=(0.0, None))
+        self.background = Parameter.default(background, name="background" + qualifier, limits=(None, None))
         self.back_absorption = Parameter.default(back_absorption, name="back_absorption" + qualifier, limits=(0.0, 1.0))
         self.theta_offset = Parameter.default(theta_offset, name="theta_offset" + qualifier)
         self.sample_broadening = Parameter.default(sample_broadening, name="sample_broadening" + qualifier)

--- a/refl1d/probe.py
+++ b/refl1d/probe.py
@@ -758,7 +758,7 @@ class Probe(BaseProbe):
             name = os.path.splitext(os.path.basename(filename))[0]
         qualifier = " " + name if name is not None else ""
         self.intensity = Parameter.default(intensity, name="intensity" + qualifier)
-        self.background = Parameter.default(background, name="background" + qualifier, limits=(None, None))
+        self.background = Parameter.default(background, name="background" + qualifier)
         self.back_absorption = Parameter.default(back_absorption, name="back_absorption" + qualifier, limits=(0.0, 1.0))
         self.theta_offset = Parameter.default(theta_offset, name="theta_offset" + qualifier)
         self.sample_broadening = Parameter.default(sample_broadening, name="sample_broadening" + qualifier)


### PR DESCRIPTION
When fitting data that has been "oversubtracted", sometimes the apparent background level is negative.

Setting a hard lower "physical" limit of 0.0 for the background parameter makes it hard to fit this type of dataset, without manually adjusting the limits after the Probe object is created

Currently, you would have to do e.g. this, to fit a negative apparent background (after initializing `Probe` object):
```python
probe.background.limits = (-float("inf"), float("inf"))
```