### PR TITLE
calculate the profile uncertainty in a thread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "bumps>=1.0.0a7",
+    "bumps>=1.0.0a8",
     "matplotlib",
     "numba",
     "numpy",


### PR DESCRIPTION
Currently the profile uncertainty is calculated in the main thread of the webserver, which is causing disconnects for long-running calculations (when nshown or npoints is large).

This PR moves the calculation to a new thread, as is already done in bumps for calculating the correlation plots.
A server-side LRU cache is also added.

The bumps fitplugin architecture is no longer used for errplot anymore after this change (the fitplugin still is used to set up problem loader etc though)

Note: this PR requires that https://github.com/bumps/bumps/pull/183 be merged first, as it uses the new `error_points_from_state` function in that PR.