### PR TITLE
Build against current bumps source (after bumps PR #188)

### DIFF
--- a/.github/workflows/test-webview-client.yaml
+++ b/.github/workflows/test-webview-client.yaml
@@ -14,11 +14,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Checkout bumps source
+        uses: actions/checkout@v4
+        with:
+          repository: bumps/bumps
+          sparse-checkout: 'bumps/webview/client'
+          path: bumps
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
       - name: Install packages
         run: bun install
+
+      - name: Use bumps code from source
+        run: |
+          cd ../../../bumps/bumps/webview/client
+          bun install
+          bun link
+          cd ../../../../refl1d/webview/client
+          bun link bumps-webview-client
+
 
       - name: Run test
         run: bun run build

--- a/refl1d/webview/client/src/main.js
+++ b/refl1d/webview/client/src/main.js
@@ -1,6 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import { computed, createApp } from "vue";
-import { fileBrowser, menu_items, model_file, socket } from "bumps-webview-client/src/app_state";
+import { file_menu_items, fileBrowser, model_file, socket } from "bumps-webview-client/src/app_state";
 import App from "bumps-webview-client/src/App.vue";
 import { dqIsFWHM } from "./app_state";
 import { panels } from "./panels.mjs";
@@ -28,4 +28,4 @@ async function loadProbeFromFile() {
 
 createApp(App, { panels, name }).mount("#app");
 const modelNotLoaded = computed(() => model_file.value == null);
-menu_items.value.push({ text: "Load Data into Model", action: loadProbeFromFile, disabled: modelNotLoaded });
+file_menu_items.value.push({ text: "Load Data into Model", action: loadProbeFromFile, disabled: modelNotLoaded });


### PR DESCRIPTION
Currently the client in master branch of refl1d won't build with the client source from bumps master branch, because of a small renaming.  This PR fixes that and allows the refl1d client to build again against bumps master branch.

### testing
Also, the test-webview-client.yml file is updated to get the current bumps webview client source and use it to build the refl1d client for testing