### PR TITLE
show y axis of reflectivity plots in scientific notation (10 to a power)

### DIFF
--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -366,7 +366,7 @@ async function draw_plot() {
         x: 0.8,
         yanchor: "top",
         y: -0.05,
-        text: `chisq = ${chisq_str.value}`,
+        text: `\u{03C7}\u{00B2} = ${chisq_str.value}`,
         showarrow: false,
         font: { size: 16 },
       },

--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -366,7 +366,7 @@ async function draw_plot() {
         x: 0.8,
         yanchor: "top",
         y: -0.05,
-        text: `\u{03C7}\u{00B2} = ${chisq_str.value}`,
+        text: `<i>\u{03C7}</i><sup>2</sup> = ${chisq_str.value}`,
         showarrow: false,
         font: { size: 16 },
       },

--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -346,7 +346,7 @@ async function draw_plot() {
     },
     yaxis: {
       title: { text: yaxis_label },
-      exponentformat: "e",
+      exponentformat: "power",
       showexponent: "all",
       type: log_y.value ? "log" : "linear",
       autorange: true,


### PR DESCRIPTION
It has been requested by @hoogerheide that the y-axis number formatting for reflectivity plots be changed to a power of 10, e.g. $10^{-6}$

# What it looks like now:
![image](https://github.com/user-attachments/assets/4da2a3c7-5614-4001-8b6a-0d06fd87d27d)

# What it would look like after this PR:
![image](https://github.com/user-attachments/assets/89563c92-208a-4d06-816d-a3caf4893c44)
