### PR TITLE
Pytest plain asserts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "bumps>=1.0.0a11",
+    "bumps>=1.0.0a12",
     "matplotlib",
     "numba",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ refl1d = "refl1d.main:cli"
 refl1d-webview = "refl1d.webview.server.webserver:main"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules --doctest-glob=*.rst --cov=refl1d"
+# TODO: remove --assert=plain when https://github.com/scipy/scipy/issues/22236 is resolved
+addopts = "--doctest-modules --doctest-glob=*.rst --cov=bumps --assert=plain"
 doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE"]
 testpaths = ["refl1d", "tests", "doc/getting_started", "doc/guide"]
 norecursedirs = ["view", "mystic", "bin", "webview/client", "explore"]


### PR DESCRIPTION
There is a conflict between the most recent scipy version (1.15) and the assertion-rewrite feature of pytest at the moment.  Until this is resolved, we can use plain assertions (no rewrite) with pytest.

The only impact is that failed assertion messages might be slightly less informative.