### PR TITLE
use uv to set up test environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
         config:
           - { os: ubuntu-latest, py: 3.9 }
           - { os: ubuntu-latest, py: "3.10" }
-          - { os: ubuntu-latest, py: "3.11", doc: 1, whl: 1 }
-          - { os: ubuntu-latest, py: "3.12" }
+          - { os: ubuntu-latest, py: "3.11" }
+          - { os: ubuntu-latest, py: "3.12", doc: 1 , whl: 1 }
           - { os: windows-latest, py: "3.12", whl: 1 }
           - { os: macos-latest, py: "3.12" }
 
@@ -24,25 +24,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+  
       - name: Set up Python ${{ matrix.config.py }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.config.py }}
 
-      - name: Install Python dependencies
+      - name: Install the project
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[dev,webview] build setuptools wheel
-          python -m build
+          uv sync --extra dev --extra webview --dev
+          uv build
 
       - name: Run tests
         run: |
-          pytest -v
-          python check_examples.py --chisq
+          uv run python -m pytest -v
+          uv run python check_examples.py --chisq
+        shell: bash
         env:
           MPLBACKEND: agg
 
       - name: Check that the docs build (linux only)
         if: matrix.config.doc == 1
         run: |
+          source .venv/bin/activate
           make -j 4 -C doc SPHINXOPTS="-W --keep-going" html


### PR DESCRIPTION
Using uv to install dependencies seems to take less than half the time of using pip (especially for Windows runners)