### PR TITLE
Migrate builder fitproblem

### DIFF
--- a/refl1d/__init__.py
+++ b/refl1d/__init__.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-__schema_version__ = "1"
+__schema_version__ = "2"
 
 BACKEND_NAMES = Literal["numba", "c_ext", "python"]
 BACKEND_NAME: BACKEND_NAMES = os.environ.get("REFL1D_BACKEND", "numba")

--- a/refl1d/bumps_interface/migrations.py
+++ b/refl1d/bumps_interface/migrations.py
@@ -70,6 +70,29 @@ def _migrate_0_to_1(serialized: dict):
     return "1", output
 
 
+def _migrate_1_to_2(serialized: dict):
+    """
+    Replace refl1d.bumps_interface.fitproblem.FitProblem with bumps.fitproblem.FitProblem
+    """
+
+    def remap(obj):
+        if isinstance(obj, dict):
+            if TYPE_KEY in obj:
+                classname: str = obj[TYPE_KEY]
+                if classname == "refl1d.bumps_interface.fitproblem.FitProblem":
+                    obj[TYPE_KEY] = "bumps.fitproblem.FitProblem"
+            for v in obj.values():
+                remap(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                remap(v)
+
+    output = deepcopy(serialized)
+    remap(output)
+    return "2", output
+
+
 MIGRATIONS = {
     "0": _migrate_0_to_1,
+    "1": _migrate_1_to_2,
 }


### PR DESCRIPTION
In a recent PR ( #258 ) we removed the module `refl1d.bumps_interface.fitproblem`.  The builder in the client was using the `FitProblem` class in that module (just a subclass of `bumps.fitproblem.FitProblem` with some extra typing hints).

This PR introduces a migration for the serialized model that converts all instances of `refl1d.bumps_interface.fitproblem.FitProblem` to `bumps.fitproblem.FitProblem` to match the current usage in the builder panel.