### PR TITLE
Automatically hide uncertainty and custom plot tabs when they are not available

### DIFF
--- a/refl1d/webview/client/src/main.js
+++ b/refl1d/webview/client/src/main.js
@@ -1,6 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import { computed, createApp } from "vue";
-import { file_menu_items, fileBrowser, model_file, socket } from "bumps-webview-client/src/app_state";
+import { file_menu_items, fileBrowser, shared_state, socket } from "bumps-webview-client/src/app_state";
 import App from "bumps-webview-client/src/App.vue";
 import { dqIsFWHM } from "./app_state";
 import { panels } from "./panels";
@@ -27,5 +27,9 @@ async function loadProbeFromFile() {
 }
 
 createApp(App, { panels, name }).mount("#app");
-const modelNotLoaded = computed(() => model_file.value == null);
-file_menu_items.value.push({ text: "Load Data into Model", action: loadProbeFromFile, disabled: modelNotLoaded });
+const modelNotLoaded = computed(() => shared_state.model_file == null);
+file_menu_items.value.push({
+  text: "Load Data into Model",
+  action: loadProbeFromFile,
+  disabled: modelNotLoaded,
+});

--- a/refl1d/webview/client/src/panels.ts
+++ b/refl1d/webview/client/src/panels.ts
@@ -1,15 +1,18 @@
-import { panels as bumps_panels } from "bumps-webview-client/src/panels";
+import { shared_state } from "bumps-webview-client/src/app_state";
+import { panels as bumps_panels, type Panel } from "bumps-webview-client/src/panels";
 import DataView from "./components/DataView.vue";
 import ModelView from "./components/ModelView.vue";
 import ProfileUncertaintyView from "./components/ProfileUncertaintyView.vue";
 import SimpleBuilder from "./components/SimpleBuilder.vue";
 
-type Panel = { title: string; component: any };
-
 const refl1dPanels: Panel[] = [
   { title: "Reflectivity", component: DataView },
   { title: "Profile", component: ModelView },
-  { title: "Profile Uncertainty", component: ProfileUncertaintyView },
+  {
+    title: "Profile Uncertainty",
+    component: ProfileUncertaintyView,
+    show: () => shared_state.uncertainty_available?.available ?? false,
+  },
   { title: "Builder", component: SimpleBuilder },
 ];
 


### PR DESCRIPTION
Uncertainty plots are only available from the server after a DREAM fit has been completed, so showing the tabs in the webview all the time is unnecessary and takes up valuable screen real estate.

This PR makes the Refl1D client code compatible with the Bumps PR https://github.com/bumps/bumps/pull/231 that has already been merged.

(also includes changes to how shared state is accessed through a central import in the client)

Without applying this PR, the Refl1D client won't work (incompatible with the current bumps client code)