### PR TITLE
support plotting ProbeSet data + theory in webview

### DIFF
--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -21,7 +21,7 @@ from bumps.webview.server.api import (
 from refl1d.uncertainty import calc_errors
 from refl1d.experiment import Experiment, ExperimentBase, MixedExperiment
 from refl1d.probe.data_loaders.load4 import load4
-from refl1d.probe import PolarizedNeutronProbe
+from refl1d.probe import PolarizedNeutronProbe, ProbeSet
 from .profile_uncertainty import show_errors
 from .profile_plot import plot_multiple_sld_profiles, ModelSpec
 
@@ -108,6 +108,8 @@ def get_probe_data(theory, probe, substrate=None, surface=None):
             if xsi is not None:
                 output.append(get_single_probe_data(xsi_th, xsi, substrate, surface, suffix))
         return output
+    elif isinstance(probe, ProbeSet):
+        return [get_single_probe_data(t, p, substrate, surface) for p, t in probe.parts(theory)]
     else:
         return [get_single_probe_data(theory, probe, substrate, surface)]
 


### PR DESCRIPTION
Currently if `Experiment.probe` is an instance of `ProbeSet`, the webview data plot function will fail.

This PR adds handling for `ProbeSet` objects