### PR TITLE
Allow duplicate Q values in probes

### DIFF
--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -856,7 +856,7 @@ class Probe(BaseProbe):
         idx = np.argsort(Q)
         self.calc_T = T[idx]
         self.calc_L = L[idx]
-        self.calc_Qo = Q[idx]
+        self.calc_Qo = np.unique(Q[idx])
 
         # Only keep the scattering factors that you need
         self.unique_L = np.unique(self.calc_L)
@@ -1398,7 +1398,7 @@ class QProbe(BaseProbe):
         self.R = R
         self.dR = dR
         self.unique_L = None
-        self.calc_Qo = self.Q
+        self.calc_Qo = np.unique(self.Q)
         self.name = name
         self.filename = filename
         self.resolution = resolution
@@ -1425,7 +1425,7 @@ class QProbe(BaseProbe):
         rng = numpy.random.RandomState(seed=seed)
         extra = rng.normal(self.Q, self.dQ, size=(n - 1, len(self.Q)))
         calc_Q = np.hstack((self.Q, extra.flatten()))
-        self.calc_Qo = np.sort(calc_Q)
+        self.calc_Qo = np.unique(calc_Q)
 
     oversample.__doc__ = Probe.oversample.__doc__
 
@@ -1433,7 +1433,7 @@ class QProbe(BaseProbe):
         Q_c = self.Q_c(substrate, surface)
         extra = np.linspace(Q_c * (1 - delta), Q_c * (1 + delta), n)
         calc_Q = np.hstack((self.Q, extra, 0))
-        self.calc_Qo = np.sort(calc_Q)
+        self.calc_Qo = np.unique(calc_Q)
 
     critical_edge.__doc__ = Probe.critical_edge.__doc__
 
@@ -1603,13 +1603,14 @@ class PolarizedNeutronProbe:
                 rng = numpy.random.RandomState(seed=self.oversampling_seed)
                 extra = rng.normal(Q_union, dQ_union, size=(self.oversampling - 1, len(Q_union)))
                 calc_Q = np.hstack((Q_union, extra.flatten()))
-                calc_Q = np.sort(calc_Q)
             else:
                 calc_Q = Q_union
 
             self.Q = Q_union
             self.dQ = dQ_union
-            self.calc_Qo = calc_Q
+            # only record the unique values of Q for calculation
+            # (np.unique will sort the values)
+            self.calc_Qo = np.unique(calc_Q)
             self._union_cache_key = union_cache_key
 
     @property
@@ -1857,7 +1858,7 @@ class PolarizedQProbe(PolarizedNeutronProbe):
         if oversampling is not None:
             self.oversample(oversampling, oversampling_seed)
         self.Q, self.dQ = Qmeasurement_union(self.xs)
-        self.calc_Qo = self.Q
+        self.calc_Qo = np.unique(self.Q)
 
     @property
     def calc_Q(self):

--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1447,8 +1447,6 @@ def Qmeasurement_union(xs):
         if x is not None:
             Qset |= set(zip(x.Q, x.dQ))
     Q, dQ = [np.array(v) for v in zip(*sorted(Qset))]
-    if abs(Q[1:] - Q[:-1]).any() < 1e-14:
-        raise ValueError("Q values differ by less than 1e-14")
     return Q, dQ
 
 

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -76,7 +76,7 @@ async def get_profile_plots(model_specs: List[ModelSpec]):
 
 def get_single_probe_data(theory, probe, substrate=None, surface=None, polarization=""):
     fresnel_calculator = probe.fresnel(substrate, surface)
-    Q, FQ = probe.apply_beam(probe.calc_Q, fresnel_calculator(probe.calc_Qo))
+    Q, FQ = probe.apply_beam(probe.calc_Q, fresnel_calculator(probe._calc_Q))
     Q, R = theory
     output: Dict[str, Union[str, np.ndarray]]
     assert isinstance(FQ, np.ndarray)


### PR DESCRIPTION
In stitched data (particularly in TOF data), it is not unusual to have multiple measurements defined for the same Q point, with different resolutions.

Currently, if a probe object is created that contains duplicate `Q` data points with different resolutions, refl1d raises an exception
(if it is a `refl1d.probe.QProbe` or a `refl1d.probe.PolarizedNeutronProbe`)

In part, I think this was in place to prevent having duplicate Q values in the calculated set of (calc_Q, calc_R) points that is used as the basis for doing the resolution correction on the modeled reflectivity (the `convolve_gaussian(...)` function in both the `refl1d.lib.c` and `refl1d.lib.python` backends has a divide-by-zero error if there are duplicate x (calc_Q) values in the inputs, **and** there are data points for which `sigma == 0` and `Q == calc_Q`).

On the other hand, the set of (calc_Q, calc_R) points is distinct from the set of data points, each of which has (Q, dQ, R, dR).  Notably, each data point has an associated dQ while the calc_Q points _do not_, so we can safely discard duplicate calc_Q points with no negative consequences.

In this PR:

- The guard is removed that explicitly raises an exception if duplicate Q are found in the set of (deduplicated) (Q, dQ) pairs
- np.unique is always applied to calc_Q before it is stored in the probe as `Probe.calc_Qo`

**NOTE** This guard has been raising an exception since 2011 (see e8730ff), so some testing to make sure that other things don't break for duplicate Q values in the data.