### PR TITLE
Show refl1d version instead of bumps version from refl1d --version

### DIFF
--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from bumps.webview.server import cli
 
 from . import api  # uses side-effects to register refl1d functions
+from refl1d import __version__
 
 # Register the refl1d model loader
 # from refl1d.bumps_interface import fitplugin
@@ -24,7 +25,7 @@ CLIENT_PATH = Path(__file__).parent.parent / "client"
 
 
 def main():
-    cli.plugin_main(name="refl1d", client=CLIENT_PATH)
+    cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR requires the changes made in 

This PR adds the refl1d version to the `cli.plugin_main` call.
It requires the changes in https://github.com/bumps/bumps/pull/259 (there is no `version` kwarg before that change), 
which means it will require `bumps>=v1.0.0b7` (not yet released)

Fixes #280