### PR TITLE
Fix QProbe serialization

### DIFF
--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1856,8 +1856,9 @@ class PolarizedQProbe(PolarizedNeutronProbe):
         self._check()
         self.name = name if name is not None else self.pp.name
         self.unique_L = None
-        self.Aguide = Parameter.default(Aguide, name="Aguide " + self.name, limits=[-360, 360])
-        self.H = Parameter.default(H, name="H " + self.name)
+        qualifier = " " + self.name if self.name is not None else ""
+        self.Aguide = Parameter.default(Aguide, name="Aguide" + qualifier, limits=[-360, 360])
+        self.H = Parameter.default(H, name="H" + qualifier)
         if oversampling is not None:
             self.oversample(oversampling, oversampling_seed)
         self.Q, self.dQ = Qmeasurement_union(self.xs)

--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1326,7 +1326,8 @@ class ProbeSet(Probe):
         return QProbe(
             Q,
             dQ,
-            data=(R, dR),
+            R=R,
+            dR=dR,
             intensity=Po.intensity,
             background=Po.background,
             back_absorption=Po.back_absorption,
@@ -1358,14 +1359,6 @@ class QProbe(BaseProbe):
     resolution: Literal["normal", "uniform"]
 
     polarized = False
-
-    @classmethod
-    def from_dict(cls, **kw):
-        R = kw.pop("R", None)
-        dR = kw.pop("dR", None)
-        if R is not None and dR is not None:
-            kw["data"] = (R, dR)
-        return cls(**kw)
 
     def __init__(
         self,

--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1371,7 +1371,9 @@ class QProbe(BaseProbe):
         self,
         Q,
         dQ,
-        data=None,
+        R=None,
+        dR=None,
+        data=None,  # deprecated
         name=None,
         filename=None,
         intensity=1,
@@ -1389,12 +1391,12 @@ class QProbe(BaseProbe):
 
         self.back_reflectivity = back_reflectivity
 
-        if data is not None:
+        if R is None and dR is None and data is not None:
+            # deprecated way of loading R and dR
             R, dR = data
-        else:
-            R, dR = None, None
 
-        self.Q, self.dQ = Q, dQ
+        self.Q = numpy.asarray(Q)
+        self.dQ = numpy.asarray(dQ)
         self.R = R
         self.dR = dR
         self.unique_L = None

--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1386,6 +1386,8 @@ class QProbe(BaseProbe):
 
         if R is None and dR is None and data is not None:
             # deprecated way of loading R and dR
+            # TODO: remove this
+            warnings.warn("data argument is deprecated, use R and dR instead")
             R, dR = data
 
         self.Q = numpy.asarray(Q)


### PR DESCRIPTION
the serialization/deserialization of QProbe objects is quirky, saving attributes `R, dR` but the init takes a `data` kwarg that is expected to be the tuple `data = (R, dR)` instead of passing `R` and `dR` directly.

This PR normalizes the serialization of QProbe so that is similar to all the other classes, initializing the same attributes that are stored.

The custom `from_dict()` loader for QProbe is also removed, because it is no longer needed (it was converting R, dR to data kw)

**NOTE**  the `data` init kwarg is retained, for backward compatibility (if you have a script that uses the `data` kwarg it will still work).  It is marked with a TODO for deprecating someday.