### PR TITLE
Fix serialization of ProbeSet

### DIFF
--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1095,9 +1095,11 @@ class NeutronProbe(Probe):
 
 
 @dataclass(init=False)
-class ProbeSet(Probe):
+class ProbeSet:
     name: Optional[str]
     probes: Sequence[Probe]
+
+    polarized = False
 
     def __init__(self, probes, name=None):
         self.probes = list(probes)


### PR DESCRIPTION
`refl1d.probe.probe.ProbeSet` class was set up as a subclass of `Probe`, but it is missing a bunch of attributes of `Probe`:

- intensity
- background
- T
- L
etc.

Because of this, it is failing to serialize in its current form (these are identified as fields of the dataclass, but are not found at serialization time), raising an error (and forcing serialization to fall back to `dill`)

In this PR, the superclass `Probe` is removed, and a static class attribute `polarized = False` is added, for compatibility with checks elsewhere in the code for whether a probe object is polarized.