### PR TITLE
remove vfs from refl1d since it is no longer in bumps

### DIFF
--- a/refl1d/main.py
+++ b/refl1d/main.py
@@ -18,17 +18,6 @@ def setup_bumps():
     """
     Install the refl1d plugin into bumps, but don't run main.
     """
-    # vfs_init must be called pretty much first since it replaces filesystem
-    # calls with filesystem hooks.  Any module that imports the calls directly
-    # e.g., using *from os.path import exists*, needs to have the hook in
-    # place before the module is even imported.
-    try:
-        from bumps.vfs import vfs_init
-
-        vfs_init()
-    except ImportError:
-        # CRUFT: older bumps doesn't provide vfs
-        pass
     import bumps.cli
 
     bumps.cli.set_mplconfig(appdatadir="Refl1D-" + __version__)


### PR DESCRIPTION
This is an optional PR since (a) it checks for vfs before loading it, and (b) it is on the code path for the old command line, which is only needed for the wx GUI.