### PR TITLE
install the fitplugin to bumps before starting cli

### DIFF
--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -10,18 +10,13 @@ from . import api  # uses side-effects to register refl1d functions
 from refl1d import __version__
 
 # Register the refl1d model loader
-# from refl1d.bumps_interface import fitplugin
-# from .profile_plot import plot_sld_profile_plotly
+# and the serialized model migrations
+from refl1d.bumps_interface import fitplugin
+from bumps.cli import install_plugin
+
+install_plugin(fitplugin)
 
 CLIENT_PATH = Path(__file__).parent.parent / "client"
-
-# from dataclasses import dataclass
-# from bumps.webview.server.cli import BumpsOptions, SERIALIZERS
-# @dataclass
-# class Refl1DOptions(BumpsOptions):
-#    serializer: SERIALIZERS = "dataclass"
-#    headless: bool = True
-# bumps_cli.OPTIONS_CLASS = Refl1DOptions
 
 
 def main():


### PR DESCRIPTION
This is needed for registering the serialized model migrations, as well as the specialized refl1d loader.

Currently the cli and webview interfaces start just fine without this PR, but older serialized models are not being migrated and therefore can't be opened.