### PR TITLE
Use trimmed MCMC for profile uncertainty plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "bumps==1.0.0b7",
+    "bumps==1.0.0b8",
     "matplotlib",
     "numba",
     "numpy",

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -150,7 +150,7 @@ def _get_profile_uncertainty_plot(
 
         start_time = time.time()
         logger.info(f"queueing new profile uncertainty plot... {start_time}")
-        error_points = error_points_from_state(uncertainty_state, nshown=nshown, random=random, portion=1.0)
+        error_points = error_points_from_state(uncertainty_state, nshown=nshown, random=random, portion=None)
         logger.info(f"points calculated: {time.time() - start_time}")
         errs = calc_errors(fitProblem, error_points)
         logger.info(f"errors calculated: {time.time() - start_time}")


### PR DESCRIPTION
Default portion to None in profile uncertainty plot so that it will use the trimmed portion if called without an explicit portion value.

The required change to bumps is already in master, though perhaps not on pypi.