### PR TITLE
add method for starting refl1d webview server from jupyter

### DIFF
--- a/refl1d/webview/server/__init__.py
+++ b/refl1d/webview/server/__init__.py
@@ -1,1 +1,1 @@
-from .cli import refl1d_server
+from .cli import start_refl1d_server

--- a/refl1d/webview/server/__init__.py
+++ b/refl1d/webview/server/__init__.py
@@ -1,0 +1,1 @@
+from .cli import start_jupyter_server

--- a/refl1d/webview/server/__init__.py
+++ b/refl1d/webview/server/__init__.py
@@ -1,1 +1,1 @@
-from .cli import start_jupyter_server
+from .cli import refl1d_server

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -16,6 +16,16 @@ from bumps.webview.server.api import (
     register,
     state,
     to_json_compatible_dict,
+    # For jupyter users:
+    set_problem,
+    start_fit_thread,
+    wait_for_fit_complete,
+    get_convergence_plot,
+    get_correlation_plot,
+    get_data_plot,
+    load_session,
+    load_problem_file,
+    set_session_output_file,
 )
 
 from refl1d.uncertainty import calc_errors

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -24,20 +24,20 @@ def main():
     cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
 
 
-def start_jupyter_server():
+def refl1d_server():
     """
     Start a Jupyter server for the webview.
+    This returns an asyncio.Task object that should be awaited
+    to ensure the server starts without exceptions.
     """
     from bumps.webview.server import api
-    from bumps.webview.server.cli import BumpsOptions
     from bumps.webview.server.webserver import start_app
 
     api.state.app_name = "refl1d"
     api.state.app_version = __version__
     api.state.client_path = CLIENT_PATH
-    options = BumpsOptions()
 
-    return asyncio.create_task(start_app(options, jupyter_link=True))
+    return asyncio.create_task(start_app(jupyter_link=True))
 
 
 if __name__ == "__main__":

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -2,6 +2,7 @@
 ***Warning***: importing cli modifies the behaviour of bumps
 """
 
+import asyncio
 from pathlib import Path
 
 from bumps.webview.server import cli
@@ -21,6 +22,22 @@ CLIENT_PATH = Path(__file__).parent.parent / "client"
 
 def main():
     cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
+
+
+def start_jupyter_server():
+    """
+    Start a Jupyter server for the webview.
+    """
+    from bumps.webview.server import api
+    from bumps.webview.server.cli import BumpsOptions
+    from bumps.webview.server.webserver import start_app
+
+    api.state.app_name = "refl1d"
+    api.state.app_version = __version__
+    api.state.client_path = CLIENT_PATH
+    options = BumpsOptions()
+
+    return asyncio.create_task(start_app(options, jupyter_link=True))
 
 
 if __name__ == "__main__":

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -24,7 +24,7 @@ def main():
     cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
 
 
-def refl1d_server():
+def start_refl1d_server():
     """
     Start a Jupyter server for the webview.
     This returns an asyncio.Task object that should be awaited


### PR DESCRIPTION
This PR creates a method for starting the webview server from within a jupyter notebook.  Usage:

```python
from refl1d.webview.server import start_refl1d_server, api

await start_refl1d_server()
# a link to open the webview server in a new tab results from this
```
then in another cell, 
```python
await api.set_problem(problem)
await api.start_fit_thread("dream", options={"steps": 1000})
await api.wait_for_fit_complete()
...
```

This fixes a bug in that after the CLI options PR, there was no way to start the webview server from a notebook (for refl1d).  And, hopefully this interface is improved over the methods that existed prior to that merge.
