### PR TITLE
Install webview dependencies by default

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           sudo apt-get install -y pandoc
-          python -m pip install .[dev,webview] build
+          python -m pip install .[dev] build
 
       - name: Build the docs
         run: |

--- a/doc/getting_started/install.rst
+++ b/doc/getting_started/install.rst
@@ -33,7 +33,7 @@ Refl1D is also available on all platforms from PyPI using pip::
     pip install refl1d
     
     # if you also want to run the webview, an optional extra is available
-    pip install refl1d[webview]
+    pip install refl1d
 
 
 Installing from source
@@ -84,7 +84,7 @@ dependencies::
 
 If you want to run the webview, you can install the optional extra::
 
-    pip install .[webview]
+    pip install .
 
 
 Installing for Development
@@ -107,9 +107,6 @@ If you are planning to contribute to the project, you will want to install
 the package in development mode, including the dev dependencies::
 
     pip install -e .[dev]
-
-    # or if you plan to develop the webview
-    pip install -e .[dev,webview]
 
 This will install the package in development mode, so that changes you make
 to the source code will be reflected in the installed package.  It will also

--- a/extra/build_conda_packed.sh
+++ b/extra/build_conda_packed.sh
@@ -17,7 +17,7 @@ conda create -y -p "$ISOLATED_ENV" "python=${PYTHON_VERSION:-3.12}" "nodejs" "mi
 cd "$SCRIPT_DIR"
 conda activate "$ISOLATED_ENV"
 
-python -m pip install --no-input --no-compile "..[webview]"
+python -m pip install --no-input --no-compile ".."
 python -m "${PACKAGE_NAME:-refl1d}.webview.build_client" --cleanup --install-dependencies
 
 conda deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "bumps==1.0.0rc1",
+    "bumps==1.0.0rc2",
     "matplotlib",
     "numba",
     "numpy",
@@ -45,7 +45,6 @@ dev = [
     "versioningit",
 ]
 full = ["wxpython", "ipython"]
-webview = ["bumps[webview]"]
 
 [project.urls]
 documentation = "https://refl1d.github.io"


### PR DESCRIPTION
Matches the bumps (merged) PR that moved the webview dependencies from an extra to the main dependencies list.

In this PR we have to remove all instances of installing the webview dependencies of bumps (as that extra no longer exists), and we remove the corresponding "webview" extra dependencies of refl1d.