### PR TITLE
use public api accessor probe.calc_Q instead of private _calc_Q

### DIFF
--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -86,7 +86,9 @@ async def get_profile_plots(model_specs: List[ModelSpec]):
 
 def get_single_probe_data(theory, probe, substrate=None, surface=None, polarization=""):
     fresnel_calculator = probe.fresnel(substrate, surface)
-    Q, FQ = probe.apply_beam(probe.calc_Q, fresnel_calculator(probe._calc_Q))
+    direction_multiplier = -1.0 if probe.back_reflectivity else 1.0
+    calc_Q = probe.calc_Q
+    Q, FQ = probe.apply_beam(calc_Q, fresnel_calculator(calc_Q * direction_multiplier))
     Q, R = theory
     output: Dict[str, Union[str, np.ndarray]]
     assert isinstance(FQ, np.ndarray)


### PR DESCRIPTION
This fixes an issue where older dill-serialized models were unable to display a reflectivity, because the private calc_Q cache attribute was changed from `probe.calc_Qo` to `probe._calc_Q` as part of a cleanup.

Now the api for generating plot data for refl1d webview uses only the public api property `probe.calc_Q`, and negates it as needed based on the value of `probe.back_reflectivity`.

This is slightly less efficient but more robust (the old way used the private `_calc_Q` in order to always get the positive version, before the back_reflectivity multiplier was applied)