### PR TITLE
toggle background in data vs theory curve

### DIFF
--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -16,7 +16,7 @@ const chisq_str = ref("");
 const log_y = ref(true);
 const log_x = ref(false);
 const show_resolution = ref(true);
-const subtract_background = ref(true);
+const apply_corrections = ref(true);
 const show_residuals = ref(false);
 
 const props = defineProps<{
@@ -66,8 +66,8 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           const color = COLORS[plot_index % COLORS.length];
           const legendgroup = `group_${plot_index}`;
           const local_offset = lin_y ? plot_index * offset : Math.pow(10, plot_index * offset);
-          const background_offset = subtract_background.value ? xs.background : 0.0;
-          const intensity_scale = subtract_background.value ? xs.intensity : 1.0;
+          const background_offset = apply_corrections.value ? xs.background : 0.0;
+          const intensity_scale = apply_corrections.value ? xs.intensity : 1.0;
           const y =
             lin_y ?
               xs.theory.map((t) => (t - background_offset) / intensity_scale + local_offset)
@@ -125,7 +125,7 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           const color = COLORS[plot_index % COLORS.length];
           const legendgroup = `group_${plot_index}`;
           const lin_y = !log_y.value;
-          const background_offset = subtract_background.value ? xs.background : 0.0;
+          const background_offset = apply_corrections.value ? xs.background : 0.0;
           const local_offset = lin_y ? plot_index * offset : Math.pow(10, plot_index * offset);
           const theory = xs.theory.map((y, i) => (y - background_offset) / (xs.fresnel[i] - background_offset));
           const offset_theory = lin_y ? theory.map((t) => t + local_offset) : theory.map((t) => t * local_offset);
@@ -189,8 +189,8 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           const legendgroup = `group_${plot_index}`;
           const local_offset = Math.pow(10, plot_index * offset);
           const { intensity, background } = xs;
-          const intensity_scale = subtract_background.value ? intensity : 1.0;
-          const background_offset = subtract_background.value ? background : 0.0;
+          const intensity_scale = apply_corrections.value ? intensity : 1.0;
+          const background_offset = apply_corrections.value ? background : 0.0;
           const Q4 = xs.Q.map((qq) => 1e-8 * Math.pow(qq, -4) * intensity_scale);
           const theory = xs.theory.map((t, i) => (t - background_offset) / Q4[i]);
           const offset_theory = theory.map((t) => t * local_offset);
@@ -251,11 +251,11 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
         const mm = model.find((xs) => xs.polarization === "--");
         const { intensity: pp_intensity, background: pp_background } = pp as ModelData;
         const { intensity: mm_intensity, background: mm_background } = mm as ModelData;
-        const pp_intensity_scale = subtract_background.value ? pp_intensity : 1.0;
-        const mm_intensity_scale = subtract_background.value ? mm_intensity : 1.0;
+        const pp_intensity_scale = apply_corrections.value ? pp_intensity : 1.0;
+        const mm_intensity_scale = apply_corrections.value ? mm_intensity : 1.0;
 
-        const pp_background_offset = subtract_background.value ? pp_background : 0.0;
-        const mm_background_offset = subtract_background.value ? mm_background : 0.0;
+        const pp_background_offset = apply_corrections.value ? pp_background : 0.0;
+        const mm_background_offset = apply_corrections.value ? mm_background : 0.0;
         const local_offset = plot_index * offset;
 
         if (pp !== undefined && mm !== undefined) {
@@ -528,13 +528,18 @@ function interp(x: number[], xp: number[], fp: number[]): number[] {
       </div>
       <div class="col-auto form-check my-2">
         <input
-          id="subtract_background"
-          v-model="subtract_background"
+          id="apply_corrections"
+          v-model="apply_corrections"
           type="checkbox"
           class="form-check-input"
           @change="draw_plot"
         />
-        <label for="subtract_background" class="form-check-label">R<sub>bkg</sub></label>
+        <label
+          for="apply_corrections"
+          class="form-check-label"
+          title="Apply background and intensity corrections to data instead of theory"
+          >R<sub>corr</sub></label
+        >
       </div>
     </div>
     <div class="row px-2 align-items-center">

--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -75,8 +75,8 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           if (xs.R !== undefined) {
             const R =
               lin_y ?
-                xs.R.map((t) => t + background_offset + local_offset)
-              : xs.R.map((t) => (t + background_offset) * local_offset);
+                xs.R.map((t) => t - background_offset + local_offset)
+              : xs.R.map((t) => (t - background_offset) * local_offset);
             const data_trace: Trace = {
               x: xs.Q,
               y: R,
@@ -135,7 +135,7 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
             line: { width: 2, color },
           });
           if (xs.R !== undefined) {
-            const R = xs.R.map((y, i) => (y + background_offset) / (xs.fresnel[i] - background_offset));
+            const R = xs.R.map((y, i) => (y - background_offset) / (xs.fresnel[i] - background_offset));
             const offset_R = lin_y ? R.map((t) => t + local_offset) : R.map((t) => t * local_offset);
             const data_trace: Trace = {
               x: xs.Q,
@@ -200,7 +200,7 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
             line: { width: 2, color },
           });
           if (xs.R !== undefined) {
-            const R = xs.R.map((r, i) => (r + background_offset) / Q4[i]);
+            const R = xs.R.map((r, i) => (r - background_offset) / Q4[i]);
             const offset_R = R.map((t) => t * local_offset);
             const data_trace: Trace = {
               x: xs.Q,

--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -67,10 +67,16 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           const legendgroup = `group_${plot_index}`;
           const local_offset = lin_y ? plot_index * offset : Math.pow(10, plot_index * offset);
           const background_offset = subtract_background.value ? xs.background : 0.0;
-          const y = lin_y ? xs.theory.map((t) => t - background_offset + local_offset) : xs.theory.map((t) => (t - background_offset) * local_offset);
+          const y =
+            lin_y ?
+              xs.theory.map((t) => t - background_offset + local_offset)
+            : xs.theory.map((t) => (t - background_offset) * local_offset);
           theory_traces.push({ x: xs.Q, y: y, mode: "lines", name: label + " theory", line: { width: 2, color } });
           if (xs.R !== undefined) {
-            const R = lin_y ? xs.R.map((t) => t + background_offset + local_offset) : xs.R.map((t) => (t + background_offset) * local_offset);
+            const R =
+              lin_y ?
+                xs.R.map((t) => t + background_offset + local_offset)
+              : xs.R.map((t) => (t + background_offset) * local_offset);
             const data_trace: Trace = {
               x: xs.Q,
               y: R,
@@ -117,7 +123,7 @@ function generate_new_traces(model_data: ModelData[][], view: ReflectivityPlot, 
           const color = COLORS[plot_index % COLORS.length];
           const legendgroup = `group_${plot_index}`;
           const lin_y = !log_y.value;
-          const background_offset = subtract_background.value ? xs.background : 0.0;          
+          const background_offset = subtract_background.value ? xs.background : 0.0;
           const local_offset = lin_y ? plot_index * offset : Math.pow(10, plot_index * offset);
           const theory = xs.theory.map((y, i) => (y - background_offset) / (xs.fresnel[i] - background_offset));
           const offset_theory = lin_y ? theory.map((t) => t + local_offset) : theory.map((t) => t * local_offset);


### PR DESCRIPTION
Pathological plotting issues are common when plotting reflectivity data, particularly when negative values of `probe.background` are present. For example, in a simple logarithmic plot, the theory curve is unreadable:
<img width="628" height="716" alt="image" src="https://github.com/user-attachments/assets/99bf2d29-c678-40c6-9953-d66b3c1f29f1" />

The problem is especially apparent when normalizing by the Fresnel reflectivity:
<img width="630" height="713" alt="image" src="https://github.com/user-attachments/assets/94ea7724-3150-42ed-816b-3aa0a0c9dd8e" />

Even linear Fresnel plots have this problem:
<img width="628" height="717" alt="image" src="https://github.com/user-attachments/assets/38016454-4650-4503-9564-b5cd2df1f68e" />

Both problems arise because the data are fixed and the theory curve moves around the data as the background changes.

This PR creates a toggle ($R_{bkg}$) that allows the theory curve to be fixed to zero reflectivity, while the background is applied to the data.
<img width="653" height="33" alt="image" src="https://github.com/user-attachments/assets/3d27512f-bfbc-49f1-8125-d3ccf2986244" />

This solves both problems:
<img width="629" height="721" alt="image" src="https://github.com/user-attachments/assets/8d5e76a0-4852-489b-847e-be0c8829faef" />
(Note that additional data are now missing from this plot, but there were already negative data missing in the original so this is not a new problem.)
<img width="624" height="725" alt="image" src="https://github.com/user-attachments/assets/1f89597a-9772-4f09-8fb0-1863417f25e9" />

For Fresnel plots, the missing data issue is easily solved by switching to a linear scale, which now looks quite reasonable:
<img width="622" height="717" alt="image" src="https://github.com/user-attachments/assets/ee8da356-83c0-41f3-8749-d25804aa2654" />
