### PR TITLE
Check parameter name before updating in magnetism

### DIFF
--- a/refl1d/sample/magnetism.py
+++ b/refl1d/sample/magnetism.py
@@ -116,7 +116,8 @@ class BaseMagnetism:
         """
         if self.name == "LAYER":
             for p in flatten(self.parameters()):
-                p.name = p.name.replace("LAYER", name)
+                if "LAYER" in p.name:
+                    p.name = p.name.replace("LAYER", name)
             self.name = name
 
 


### PR DESCRIPTION
The awful hack here:
https://github.com/reflectometry/refl1d/blob/83cd351a521ca6814b51470f626c30adce7f0bc9/refl1d/sample/magnetism.py#L111-L120
invoked from here:
https://github.com/reflectometry/refl1d/blob/83cd351a521ca6814b51470f626c30adce7f0bc9/refl1d/sample/layers.py#L57-L62
fails when the magnetism parameter is initialized from an expression.

Parameter expressions in bumps have name as a property that expands to the string form of the expression. The name property in this case has no setter.
https://github.com/bumps/bumps/blob/cdf1b764b9e22dbc9dccdd08bd150839a8dd7826/bumps/parameter.py#L926-L928

Checking for LAYER in the parameter name as in the code above will avoids this issue.

We may want to update Expression so that name is an normal attribute initialized to the expression, giving the user control over the display name, but that is an independent issue.