### PR TITLE
Enable batch align and contour export

### DIFF
--- a/refl1d/uncertainty.py
+++ b/refl1d/uncertainty.py
@@ -64,7 +64,7 @@ def run_errors(**kw):
 
         *nshown*, *random* :
 
-            see :func:`bumps.errplot.calc_errors_from_state`
+            see :func:`bumps.errplot.error_points_from_state`
 
         *contours*, *npoints*, *plots*, *save* :
 

--- a/refl1d/uncertainty.py
+++ b/refl1d/uncertainty.py
@@ -47,7 +47,7 @@ def run_errors(**kw):
 
     Type the following to regenerate the profile contour plots plots:
 
-        $ refl1d align <model>.py <store> [<align>] [0|1|2|n]
+        $ refl1d align <model>.py <store> [<layer>.<offset>] [0|1|2|n]
 
     Align is either auto for the current behaviour, or it is an interface
     number. You can align on the center of a layer by adding 0.5 to the
@@ -110,6 +110,7 @@ def run_errors(**kw):
         import matplotlib.pyplot as plt
 
         plt.show()
+
     sys.exit(0)  # Force refl1d to terminate.
 
 
@@ -276,9 +277,11 @@ def show_errors(errors, contours=CONTOURS, npoints=200, align="auto", plots=1, s
     if fig is not None and plots != 1:
         raise ValueError("can only pass in a figure object if exactly 1 plot is requested")
 
-    if plots == 0:  # Don't create plots, just save the data
+    if save:  # Don't create plots, just save the data
         _save_profile_data(errors, contours=contours, npoints=npoints, align=align, save=save)
         _save_residual_data(errors, contours=contours, save=save)
+    if plots == 0:
+        ... # Contours saved but no plotting
     elif plots == 1:  # Subplots for profiles/residuals
         if fig is None:
             fig = plt.gcf()

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -2,6 +2,7 @@
 ***Warning***: importing cli modifies the behaviour of bumps
 """
 
+import sys
 import asyncio
 from pathlib import Path
 
@@ -21,7 +22,17 @@ CLIENT_PATH = Path(__file__).parent.parent / "client"
 
 
 def main():
-    cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
+    if len(sys.argv) > 1 and sys.argv[1] == "align":
+        # Command line tool to regenerate the profile uncertainty plot:
+        #
+        #   refl1d align <model>.py <store> [<layer>.<offset>] [0|1|2|n]
+        #
+        from refl1d.uncertainty import run_errors
+
+        del sys.argv[1]
+        run_errors()
+    else:
+        cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
 
 
 def start_refl1d_server():


### PR DESCRIPTION
Enable the "refl1d align ..." hack to rerun the profile uncertainty plot from an exported uncertainty sample in the new command line interface.

Modify the behaviour to always save the contour data, even when plotting. The old version used "0" to export the contours and "1", "2" or "n" to generate the plots.

This version loads state only from the exported results directory. It may be useful to support session files as well, though with GUI support for selecting alignment position in refl1d webview, this is not a priority.