### PR TITLE
Fix profile uncertainty plots not updating

### DIFF
--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -2,7 +2,7 @@ import asyncio
 from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 # import bumps.webview.server.api as bumps_api
 import numpy as np
@@ -151,6 +151,7 @@ def _get_profile_uncertainty_plot(
     npoints: int = 5000,
     random: bool = True,
     residuals: bool = False,
+    latest_timestamp: Optional[str] = None,
 ):
     if state.problem is None or state.problem.fitProblem is None:
         return None
@@ -186,6 +187,7 @@ async def get_profile_uncertainty_plot(
     npoints: int = 5000,
     random: bool = True,
     residuals: bool = False,
+    latest_timestamp: Optional[str] = None,
 ):
     result = await asyncio.to_thread(
         _get_profile_uncertainty_plot,
@@ -195,6 +197,7 @@ async def get_profile_uncertainty_plot(
         npoints=npoints,
         random=random,
         residuals=residuals,
+        latest_timestamp=latest_timestamp,
     )
     return result
 


### PR DESCRIPTION
There is a client-side cache of the profile uncertainty plots that serves little purpose, and the signature of the server function that generates these plots with an lru cache is insufficient to react to uncertainty updates.

This PR adds the timestamp (from the most recent uncertainty update) to the signature of the server-side lru_cache function that generates profile uncertainty plots, and it removes the client-side cache that was causing problems and almost never could help anything.

After this change, profile uncertainty plots update correctly whenever an `updated_uncertainty` signal is sent with a new timestamp (including when the trim portion is updated)