### PR TITLE
Fix control names in Profile Uncertainty panel

### DIFF
--- a/refl1d/webview/client/src/components/ProfileUncertaintyView.vue
+++ b/refl1d/webview/client/src/components/ProfileUncertaintyView.vue
@@ -123,6 +123,7 @@ async function fetch_and_draw(new_timestamp?: string) {
 async function disableAutoAlign() {
   if (autoAlign.value) {
     autoAlign.value = false;
+    await fetch_and_draw();
   }
 }
 </script>


### PR DESCRIPTION
update names of controls in Profile Uncertainty panel, to be more directly descriptive of what they do.

Also adds a convenience: click on the "Alignment Interface" input will disable "Auto-align", for faster entry.