### PR TITLE
Fix error shown at startup of client when no reflectivity data to plot

### DIFF
--- a/refl1d/webview/client/src/components/DataView.vue
+++ b/refl1d/webview/client/src/components/DataView.vue
@@ -339,6 +339,13 @@ async function fetch_and_draw() {
     plotdata: ModelData[][];
     chisq: string;
   };
+  if (payload?.plotdata == null) {
+    // clear plot and return if no plot data is available
+    if (plot_div.value) {
+      await Plotly.purge(plot_div.value);
+    }
+    return;
+  }
   plot_data.value = payload.plotdata;
   chisq_str.value = payload.chisq;
   await draw_plot();


### PR DESCRIPTION
Prevent executing plot function when plotdata from server is null.

Fixes error shown in client at startup:

<img width="393" height="152" alt="image" src="https://github.com/user-attachments/assets/f43e2837-f3f1-4fae-8d50-a0abe13bf928" />
