### PR TITLE
always send the background and intensity values to plotter

### DIFF
--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -103,11 +103,11 @@ def get_single_probe_data(theory, probe, substrate=None, surface=None, polarizat
             dR=probe.dR,
             theory=R,
             fresnel=FQ,
-            background=probe.background.value,
-            intensity=probe.intensity.value,
         )
     else:
         output = dict(Q=probe.Q, dQ=probe.dQ, theory=R, fresnel=FQ)
+    output["background"] = probe.background.value
+    output["intensity"] = probe.intensity.value
     output["polarization"] = polarization
     output["label"] = probe.label()
     return output


### PR DESCRIPTION
When no data was attached to problem, API was not sending background and intensity values with `get_plot_data`.

This PR fixes that.  Replaces now-unneeded #345