### PR TITLE
Try to fix DMG create issues with MacOS installer build

### DIFF
--- a/.github/workflows/build-distributables.yml
+++ b/.github/workflows/build-distributables.yml
@@ -107,6 +107,10 @@ jobs:
         codesign --verify --options=runtime --timestamp --verbose=4 --force --sign "${DEVELOPER_IDENTITY}" "$APP"
         codesign --verify --options=runtime --timestamp --verbose=4 --force --sign "${DEVELOPER_IDENTITY}" "$APP_FOLDER/${PACKAGE_NAME}_shell.app"
 
+        # After signing, ensure all writes are flushed
+        sync
+        sleep 2
+
         DMG="artifacts/$FULL_PACKAGE_NAME.dmg"
         mkdir -p artifacts
         hdiutil create $DMG -srcfolder "$BUILD_DIR" -ov -format UDZO


### PR DESCRIPTION
occasional errors when running DMG build for macos - this might fix it (flush all writes before creating DMG)

see https://github.com/reflectometry/refl1d/actions/runs/19505823476/job/55831661647#step:5:988
