### PR TITLE
update to vite 8 (fast client builds)

### DIFF
--- a/refl1d/webview/client/package.json
+++ b/refl1d/webview/client/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^24.5.2",
     "@types/plotly.js": "^3.0.9",
     "@types/uuid": "^10.0.0",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@vitejs/plugin-vue": "^6.0.5",
     "@vue/eslint-config-prettier": "10.1.0",
     "@vue/eslint-config-typescript": "^14.2.0",
     "@vue/tsconfig": "^0.7.0",
@@ -48,7 +48,7 @@
     "prettier-plugin-css-order": "^2.1.2",
     "prettier-plugin-jsdoc": "^1.3.2",
     "typescript": "^5.7.3",
-    "vite": "^6.0.7",
+    "vite": "^8.0.2",
     "vite-svg-loader": "5.1.0",
     "vue-tsc": "^2.2.0"
   }


### PR DESCRIPTION
Vite 8 was recently released, and it uses `rolldown` which is a much faster bundling engine.  As a result build times for the client are about 1s, compared to 8-9 seconds before.  Makes client development more pleasant.