### PR TITLE
adjust imports to bumps 1.1 reorganized tree

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,11 +37,10 @@ print("\n".join(sys.path))
 print("== end path ==")
 
 # Register the refl1d model loader
-import bumps.cli
-
+from bumps.plugin import install_plugin
 from refl1d.bumps_interface import fitplugin
 
-bumps.cli.install_plugin(fitplugin)
+install_plugin(fitplugin)
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,11 @@ print("\n".join(sys.path))
 print("== end path ==")
 
 # Register the refl1d model loader
-from bumps.plugin import install_plugin
+try:
+    from bumps.plugin import install_plugin
+except ImportError:
+    # CRUFT: bumps < 1.1
+    from bumps.cli import install_plugin
 from refl1d.bumps_interface import fitplugin
 
 install_plugin(fitplugin)

--- a/doc/sitedoc.py
+++ b/doc/sitedoc.py
@@ -2,7 +2,7 @@ import os
 import numpy
 import pylab
 import bumps.fitters as fit
-from bumps.cli import load_model
+from bumps.fitproblem import load_problem
 
 SEED = 1
 
@@ -43,7 +43,7 @@ def example_dir():
 def plot_model(filename):
     # import sys; print >>sys.stderr, "in plot with",filename, example_dir()
     numpy.random.seed(SEED)
-    p = load_model(os.path.join(example_dir(), filename))
+    p = load_problem(os.path.join(example_dir(), filename))
     p.plot()
     pylab.show()
 
@@ -51,7 +51,7 @@ def plot_model(filename):
 def fit_model(filename):
     # import sys; print >>sys.stderr, "in plot with",filename, example_dir()
     numpy.random.seed(SEED)
-    p = load_model(os.path.join(example_dir(), filename))
+    p = load_problem(os.path.join(example_dir(), filename))
     # x.fx = fit.RLFit(p).solve(steps=1000, burn=99)
     # x,fx = fit.DEFit(p).solve(steps=200, pop=10)
     # x,fx = fit.PTFit(p).solve(steps=100,burn=400)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "bumps==1.0.5a0",
+    "bumps>=1.1",
     "matplotlib",
     "numba",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "bumps>=1.1",
+    "bumps>=1.0.4",
     "matplotlib",
     "numba",
     "numpy",

--- a/refl1d/main.py
+++ b/refl1d/main.py
@@ -18,12 +18,12 @@ def setup_bumps():
     """
     Install the refl1d plugin into bumps, but don't run main.
     """
-    import bumps.cli
-
-    bumps.cli.set_mplconfig(appdatadir="Refl1D-" + __version__)
+    from bumps.plotutil import set_mplconfig
+    from bumps.plugin import install_plugin
     from .bumps_interface import fitplugin
 
-    bumps.cli.install_plugin(fitplugin)
+    set_mplconfig(appdatadir="Refl1D-" + __version__)
+    install_plugin(fitplugin)
 
 
 def cli():
@@ -39,9 +39,9 @@ def cli():
         del sys.argv[1]
         run_errors()
     else:
-        import bumps.cli
+        from bumps.gui.old_cli import main as old_main
 
-        bumps.cli.main()
+        old_main()
 
 
 def gui():

--- a/refl1d/main.py
+++ b/refl1d/main.py
@@ -19,7 +19,12 @@ def setup_bumps():
     Install the refl1d plugin into bumps, but don't run main.
     """
     from bumps.plotutil import set_mplconfig
-    from bumps.plugin import install_plugin
+
+    try:
+        from bumps.plugin import install_plugin
+    except ImportError:
+        # CRUFT: bumps < 1.1
+        from bumps.cli import install_plugin
     from .bumps_interface import fitplugin
 
     set_mplconfig(appdatadir="Refl1D-" + __version__)
@@ -39,8 +44,11 @@ def cli():
         del sys.argv[1]
         run_errors()
     else:
-        from bumps.gui.old_cli import main as old_main
-
+        try:
+            from bumps.gui.old_cli import main as old_main
+        except ImportError:
+            # CRUFT: bumps < 1.1
+            from bumps.cli import main as old_main
         old_main()
 
 

--- a/refl1d/probe/oversampling.py
+++ b/refl1d/probe/oversampling.py
@@ -123,7 +123,7 @@ def analyze_fitproblem(problem, tolerance=0.05, max_oversampling=201, seed=1, pl
 
 def main():
     import sys
-    from bumps.cli import load_model, load_best
+    from bumps.fitproblem import load_problem, load_pars
 
     parser = argparse.ArgumentParser(
         description="""
@@ -161,9 +161,9 @@ def main():
 
     opts = parser.parse_args(None if sys.argv[1:] else ["-h"])
 
-    problem = load_model(opts.modelfile[0], model_options=opts.modelopts)
+    problem = load_problem(opts.modelfile[0], model_options=opts.modelopts)
     if opts.pars:
-        load_best(problem, opts.pars)
+        load_pars(problem, opts.pars)
 
     analyze_fitproblem(problem, tolerance=opts.tolerance, max_oversampling=opts.max_oversampling, plot=opts.plot)
 

--- a/refl1d/webview/server/__main__.py
+++ b/refl1d/webview/server/__main__.py
@@ -1,3 +1,4 @@
 if __name__ == "__main__":
     from bumps.cli import main as new_main
+
     new_main()

--- a/refl1d/webview/server/__main__.py
+++ b/refl1d/webview/server/__main__.py
@@ -1,4 +1,3 @@
-from .cli import main
-
 if __name__ == "__main__":
-    main()
+    from bumps.cli import main as new_main
+    new_main()

--- a/refl1d/webview/server/__main__.py
+++ b/refl1d/webview/server/__main__.py
@@ -1,8 +1,8 @@
 if __name__ == "__main__":
     try:
+        # CRUFT: bumps < 1.1
         from bumps.webview.server.cli import main as new_main
     except ImportError:
-        # CRUFT: bumps < 1.1
         from bumps.cli import main as new_main
 
     new_main()

--- a/refl1d/webview/server/__main__.py
+++ b/refl1d/webview/server/__main__.py
@@ -1,4 +1,8 @@
 if __name__ == "__main__":
-    from bumps.cli import main as new_main
+    try:
+        from bumps.webview.server.cli import main as new_main
+    except ImportError:
+        # CRUFT: bumps < 1.1
+        from bumps.cli import main as new_main
 
     new_main()

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -4,10 +4,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-# import bumps.webview.server.api as bumps_api
+# import bumps..api as bumps_api
 import numpy as np
 from bumps.errplot import error_points_from_state
-from bumps.webview.server.api import (
+from bumps.api import (
     add_notification,
     get_chisq,
     log,

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -7,6 +7,16 @@ from typing import Dict, List, Optional, Union
 # import bumps..api as bumps_api
 import numpy as np
 from bumps.errplot import error_points_from_state
+
+try:
+    import bumps.api
+except ImportError:
+    # CRUFT: bumps < 1.1; installs bumps.webview.server.api into bumps.api
+    import sys
+    import bumps.webview.server.api as api
+
+    sys.modules["bumps.api"] = api
+
 from bumps.api import (
     add_notification,
     get_chisq,

--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -11,7 +11,7 @@ from bumps.errplot import error_points_from_state
 try:
     import bumps.api
 except ImportError:
-    # CRUFT: bumps < 1.1; installs bumps.webview.server.api into bumps.api
+    # CRUFT: bumps < 1.1; redirect bumps.api to bumps.webview.server.api
     import sys
     import bumps.webview.server.api as api
 

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -6,7 +6,7 @@ import sys
 import asyncio
 from pathlib import Path
 
-from bumps.webview.server import cli
+from bumps import cli
 
 from . import api  # uses side-effects to register refl1d functions
 from refl1d import __version__
@@ -14,7 +14,7 @@ from refl1d import __version__
 # Register the refl1d model loader
 # and the serialized model migrations
 from refl1d.bumps_interface import fitplugin
-from bumps.cli import install_plugin
+from bumps.plugin import install_plugin
 
 install_plugin(fitplugin)
 
@@ -41,8 +41,8 @@ def start_refl1d_server():
     This returns an asyncio.Task object that should be awaited
     to ensure the server starts without exceptions.
     """
-    from bumps.webview.server import api
-    from bumps.webview.server.webserver import start_app
+    from bumps.webview.webserver import start_app
+
 
     api.state.app_name = "refl1d"
     api.state.app_version = __version__

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -43,7 +43,6 @@ def start_refl1d_server():
     """
     from bumps.webview.webserver import start_app
 
-
     api.state.app_name = "refl1d"
     api.state.app_version = __version__
     api.state.client_path = CLIENT_PATH

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -1,5 +1,11 @@
 """
-***Warning***: importing cli modifies the behaviour of bumps
+Refl1D entry points.
+
+*main()* starts bumps with the Refl1D plugin when *refl1d* is given on the command line.
+
+*start_refl1d_server()* starts bumps with the Refl1D plugin from jupyter notebooks.
+
+***Warning***: importing refl1d.webview.server modifies the behaviour of bumps
 """
 
 import sys
@@ -16,10 +22,12 @@ from refl1d.bumps_interface import fitplugin
 try:
     from bumps.plugin import install_plugin
     from bumps.cli import plugin_main
+    from bumps.webview.webserver import start_app
 except ImportError:
     # CRUFT: bumps < 1.1
     from bumps.cli import install_plugin
     from bumps.webview.server.cli import plugin_main
+    from bumps.webview.server.webserver import start_app
 
 install_plugin(fitplugin)
 
@@ -27,6 +35,9 @@ CLIENT_PATH = Path(__file__).parent.parent / "client"
 
 
 def main():
+    """
+    Run refl1d from the command line.
+    """
     if len(sys.argv) > 1 and sys.argv[1] == "align":
         # Command line tool to regenerate the profile uncertainty plot:
         #
@@ -46,8 +57,6 @@ def start_refl1d_server():
     This returns an asyncio.Task object that should be awaited
     to ensure the server starts without exceptions.
     """
-    from bumps.webview.webserver import start_app
-
     api.state.app_name = "refl1d"
     api.state.app_version = __version__
     api.state.client_path = CLIENT_PATH

--- a/refl1d/webview/server/cli.py
+++ b/refl1d/webview/server/cli.py
@@ -6,15 +6,20 @@ import sys
 import asyncio
 from pathlib import Path
 
-from bumps import cli
-
 from . import api  # uses side-effects to register refl1d functions
 from refl1d import __version__
 
 # Register the refl1d model loader
 # and the serialized model migrations
 from refl1d.bumps_interface import fitplugin
-from bumps.plugin import install_plugin
+
+try:
+    from bumps.plugin import install_plugin
+    from bumps.cli import plugin_main
+except ImportError:
+    # CRUFT: bumps < 1.1
+    from bumps.cli import install_plugin
+    from bumps.webview.server.cli import plugin_main
 
 install_plugin(fitplugin)
 
@@ -32,7 +37,7 @@ def main():
         del sys.argv[1]
         run_errors()
     else:
-        cli.plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
+        plugin_main(name="refl1d", client=CLIENT_PATH, version=__version__)
 
 
 def start_refl1d_server():

--- a/refl1d/webview/server/names.py
+++ b/refl1d/webview/server/names.py
@@ -5,7 +5,7 @@ try:
     from bumps.names import set_problem, load_session
     from bumps.api import state
     from bumps.webview.webserver import start_app, sio
-except ImportError: # CRUFT: bumps 1.1 rearranged internal structure
+except ImportError:  # CRUFT: bumps 1.1 rearranged internal structure
     from bumps.webview.server.api import state, set_problem, load_session
     from bumps.webview.server.webserver import start_app, sio
 

--- a/refl1d/webview/server/names.py
+++ b/refl1d/webview/server/names.py
@@ -1,8 +1,12 @@
-# from bumps.webview.server.api import state, set_problem, load_session
+# from bumps.api import state, set_problem, load_session
 # from .webserver import main, start_app, create_server_task, sio
 
-
-from bumps.webview.server.api import state, set_problem, load_session
-from bumps.webview.server.webserver import start_app, sio
+try:
+    from bumps.names import set_problem, load_session
+    from bumps.api import state
+    from bumps.webview.webserver import start_app, sio
+except ImportError: # CRUFT: bumps 1.1 rearranged internal structure
+    from bumps.webview.server.api import state, set_problem, load_session
+    from bumps.webview.server.webserver import start_app, sio
 
 from .cli import main

--- a/tests/refl1d/test_scriptify.py
+++ b/tests/refl1d/test_scriptify.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import shutil
 
 import pytest
-from bumps.cli import load_model
+from bumps.fitproblem import load_problem
 from refl1d.webview.server.scriptify import serialize_fitproblem
 
 
@@ -40,7 +40,7 @@ def test_scriptify_refl1d_model(temp_model_dir):
     """Test that a refl1d model can be scriptified and re-loaded."""
     # Load the example model
     model_path = Path(__file__).parent.parent.parent / "doc" / "examples" / "xray" / "model.py"
-    fit_problem = load_model(str(model_path))
+    fit_problem = load_problem(str(model_path))
 
     # Scriptify the fit problem
     script = serialize_fitproblem(fit_problem)

--- a/tests/refl1d/test_scriptify.py
+++ b/tests/refl1d/test_scriptify.py
@@ -58,7 +58,7 @@ def test_scriptify_refl1d_model(temp_model_dir):
     original_cwd = os.getcwd()
     try:
         os.chdir(temp_model_dir)
-        reloaded_fit_problem = load_model(str(temp_script_path))
+        reloaded_fit_problem = load_problem(str(temp_script_path))
 
         # Compare key attributes of the original and reloaded fit problems
         assert len(list(fit_problem.models)) == len(list(reloaded_fit_problem.models))


### PR DESCRIPTION
Minimal change to keep refl1d working with the bumps tree reorganization to be released as 1.1.

It includes cruft to support bumps 1.0.4+