### PR TITLE
fix(webview): prevent network-drive stalls in file browser dirlisting

### DIFF
--- a/refl1d/webview/server/api.py
+++ b/refl1d/webview/server/api.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
@@ -237,3 +238,50 @@ async def export_model_script(pathlist: List[str], filename: str):
         with open(path / filename, "w") as f:
             f.write(s)
         await add_notification(content=f"to {filename}", title="Model exported:", timeout=2000)
+
+
+def _get_dirlisting_sync(pathlist: Optional[List[str]] = None):
+    """Directory listing that avoids per-subfolder glob (network drive safe)."""
+    subfolders = []
+    files = []
+    path = Path(state.base_path) if (pathlist is None or len(pathlist) == 0) else Path(*pathlist)
+    if not path.exists():
+        return {"error": f"Path does not exist: {path}"}
+
+    abs_path = path.absolute()
+    try:
+        entries = list(abs_path.iterdir())
+    except PermissionError:
+        return {"error": f"Permission denied: {abs_path}"}
+    except OSError as exc:
+        return {"error": f"Cannot read directory: {exc}"}
+
+    for p in entries:
+        try:
+            stat = p.stat()
+        except (OSError, PermissionError):
+            continue
+        mtime = stat.st_mtime
+        fileinfo = {"name": p.name, "modified": mtime}
+        if p.is_dir():
+            fileinfo["size"] = 0
+            subfolders.append(fileinfo)
+        else:
+            fileinfo["size"] = stat.st_size
+            files.append(fileinfo)
+
+    drives = os.listdrives() if hasattr(os, "listdrives") else []
+    return dict(drives=drives, pathlist=abs_path.parts, subfolders=subfolders, files=files)
+
+
+@register
+async def get_dirlisting(pathlist: Optional[List[str]] = None):
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_get_dirlisting_sync, pathlist),
+            timeout=10.0,
+        )
+    except asyncio.TimeoutError:
+        path_str = str(Path(*pathlist)) if pathlist else "(base)"
+        return {"error": f"Timed out reading {path_str} — network drive may be unreachable"}
+    return result


### PR DESCRIPTION
## Problem

The webview file browser hangs for 30+ seconds when navigating network drives.

The root cause is in `bumps.webview.server.api.get_dirlisting` (which refl1d uses). For every directory entry it:

- counts each subdirectory's contents with `len(list(p.glob("*")))` — a full glob *per subfolder*, and
- does a redundant `p.exists()` check on entries just returned by `iterdir()`,

all **synchronously on the asyncio event loop**. On a high-latency network filesystem each glob is a round trip, so a folder with many subfolders blocks the server for tens of seconds and the whole UI freezes.

## Fix

Override `get_dirlisting` in `refl1d/webview/server/api.py` with a version that:

- **skips per-subfolder content counting** (`size = 0` for directories — the count isn't shown in the UI anyway),
- **drops the redundant `exists()` check**,
- runs the directory walk in a **worker thread** (`asyncio.to_thread`) so it never blocks the event loop, and
- adds a **10 s timeout** that returns a friendly error instead of hanging when a path is unreachable.

The return value is **identical in shape** to bumps' `get_dirlisting` (`drives`, `pathlist`, `subfolders`, `files`), so it is a drop-in replacement for the existing frontend.

## Notes / discussion

- The slow code lives in **bumps**, not refl1d — this PR overrides it on the refl1d side. If you'd rather fix it upstream in `bumps.webview.server.api.get_dirlisting` directly (benefiting every bumps-webview consumer, and avoiding a duplicated function here), I'm glad to redirect this there instead.
- Minor behavioral change: when a path does not exist, this returns `{"error": ...}` rather than bumps' "notify + fall back to cwd". Trivial to match bumps' behavior if preferred.
- `os.listdrives()` is Windows / Python 3.12+ and is guarded by `hasattr` exactly as in bumps, so non-Windows platforms get `drives = []`.

## Testing

- `py_compile` clean; confirmed the return shape matches bumps' `get_dirlisting`.
- Developed against a real network-drive stall on Windows: navigation that previously hung ~30 s now returns promptly, and unreachable paths time out at 10 s with an error instead of freezing the UI.
