### PR TITLE
Enable repeated magnetic layers

### DIFF
--- a/refl1d/sample/layers.py
+++ b/refl1d/sample/layers.py
@@ -370,7 +370,7 @@ class Stack(Layer):
                 anchor = slabs.thickness() + magnetism.dead_below.value
                 s_below = (
                     np.nan
-                    if i == 0
+                    if len(slabs) == 0
                     else magnetism.interface_below.value
                     if magnetism.interface_below is not None
                     else slabs.surface_sigma
@@ -664,9 +664,21 @@ class Repeat(Layer):
         nr = self.repeat.value
         if nr <= 0:
             return
-        mark = len(slabs)
-        self.stack.render(probe, slabs)
-        slabs.repeat(mark, int(nr), interface=self.interface.value)
+
+        if self.ismagnetic:
+            # Dynamically loop during rendering so 'repeat' remains a fittable Parameter
+            for _ in range(int(nr)):
+                self.stack.render(probe, slabs)
+
+            # Manually apply the top interface to the final slab of the sequence,
+            # mimicking what slabs.repeat() would have done internally.
+            if len(slabs) > 0:
+                slabs._slabs[slabs._num_slabs - 1, 1] = self.interface.value
+        else:
+            # Keep the optimized vectorized array-tiling for non-magnetic stacks
+            mark = len(slabs)
+            self.stack.render(probe, slabs)
+            slabs.repeat(mark, int(nr), interface=self.interface.value)
 
     def __str__(self):
         return "(%s)x%d" % (str(self.stack), self.repeat.value)

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -15,8 +15,8 @@ from refl1d.probe.probe import PolarizedNeutronProbe, NeutronProbe
 from refl1d.experiment import Experiment
 
 
-def build_multilayer(N=2, flat=False):
-    """Build a multilayer using Repeat structure."""
+def build_experiments(N=2):
+    """Build a multilayer."""
     Si = material.Material(formula="Si")
     Ni = material.Material(formula="Ni[58]")
     Si_ml = material.Material(formula="Si")
@@ -31,27 +31,23 @@ def build_multilayer(N=2, flat=False):
     )
     Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
 
+    Si_ml.density.range(0, 10)
+    Ni.density.range(0, 10)
     Ni_layer.thickness.range(50, 200)
     Ni_layer.interface.range(1, 20)
     Ni_layer.magnetism.rhoM.range(0, 5)
     Si_layer.thickness.range(50, 200)
     Si_layer.interface.range(1, 20)
 
-    if flat:
-        multilayer = (Ni_layer, Si_layer) * N
-    else:
-        multilayer = (Ni_layer | Si_layer) * N
-
     # Substrate and repeat
     Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
 
-    return Si_sub | multilayer | air
-
-
-def build_experiments(N=2):
     # Build both samples
-    sample_repeat = build_multilayer(N, flat=False)
-    sample_flat = build_multilayer(N, flat=True)
+    ML_flat = (Ni_layer, Si_layer)*N
+    ML_repeat = (Ni_layer | Si_layer)*N
+    ML_repeat.interface = Si_layer.interface
+    sample_flat = Si_sub | ML_flat | air  # flat
+    sample_repeat = Si_sub | ML_repeat | air  # repeat
 
     # Create T and L arrays
     T = np.logspace(-3, 0, 50)

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -199,4 +199,3 @@ if __name__ == "__main__":
     print("\n" + "=" * 70)
     print("✓ ALL TESTS PASSED FOR ALL N VALUES")
     print("=" * 70)
-

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -14,68 +14,42 @@ from refl1d.probe.probe import PolarizedNeutronProbe, NeutronProbe
 from refl1d.experiment import Experiment
 
 
-def build_repeat_multilayer(N=2):
+def build_multilayer(N=2, flat=False):
     """Build a multilayer using Repeat structure."""
     Si = material.Material(formula="Si")
     Ni = material.Material(formula="Ni[58]")
     Si_ml = material.Material(formula="Si")
     air = material.Vacuum()
 
+
     # Single bilayer (Ni|Si)
     Ni_layer = layers.Slab(
         material=Ni,
         thickness=100,
         interface=5,
+        magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
     )
     Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
-    bilayer = (
-        Ni_layer(
-            magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
-        )
-        | Si_layer
-    )
+
+    Ni_layer.thickness.range(50, 200)
+    Ni_layer.interface.range(1, 20)
+    Si_layer.thickness.range(50, 200)
+    Si_layer.interface.range(1, 20)
+
+    if flat:
+        multilayer = (Ni_layer, Si_layer)*N
+    else:
+        multilayer = (Ni_layer | Si_layer)*N
 
     # Substrate and repeat
     Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
-    ML = bilayer * N
 
-    return Si_sub | ML | air
+    return Si_sub | multilayer | air
 
-
-def build_flattened_multilayer(N=2):
-    """Build a multilayer by repeating layer objects N times."""
-    Si = material.Material(formula="Si")
-    Ni = material.Material(formula="Ni[58]")
-    Si_ml = material.Material(formula="Si")
-    air = material.Vacuum()
-
-    Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
-
-    # Build the stack by repeating the same layer objects
-    # (bumps will deduplicate by id, giving shared parameters)
-    Ni_layer = layers.Slab(
-        material=Ni,
-        thickness=100,
-        interface=5,
-    )
-    Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
-
-    bilayer = (
-        Ni_layer(
-            magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
-        ),
-        Si_layer,
-    )
-    ML = bilayer * N
-
-    return Si_sub | ML | air
-
-
-def test_multilayer_equivalence(N=2):
-    """Test that Repeat and flattened structures give identical results."""
+def build_experiments(N=2):
     # Build both samples
-    sample_repeat = build_repeat_multilayer(N)
-    sample_flat = build_flattened_multilayer(N)
+    sample_repeat = build_multilayer(N, flat=False)
+    sample_flat = build_multilayer(N, flat=True)
 
     # Create T and L arrays
     T = np.logspace(-3, 0, 50)
@@ -93,6 +67,11 @@ def test_multilayer_equivalence(N=2):
     # Create experiments
     exp_repeat = Experiment(sample=sample_repeat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
     exp_flat = Experiment(sample=sample_flat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
+    return exp_repeat, exp_flat
+
+def test_multilayer_equivalence(N=2):
+    """Test that Repeat and flattened structures give identical results."""
+    exp_repeat, exp_flat = build_experiments(N)
 
     # Compare reflectivity
     print(f"\n{'=' * 70}")
@@ -199,7 +178,7 @@ def test_multilayer_equivalence(N=2):
 
 if __name__ == "__main__":
     # Test for different repeat counts
-    for N in [1, 2, 3, 10]:
+    for N in [2, 3, 10]:
         try:
             test_multilayer_equivalence(N)
         except Exception as e:
@@ -213,3 +192,9 @@ if __name__ == "__main__":
     print("\n" + "=" * 70)
     print("✓ ALL TESTS PASSED FOR ALL N VALUES")
     print("=" * 70)
+
+else:
+    # Allow loading into refl1d
+    from bumps.names import FitProblem
+
+    problem = FitProblem(build_experiments(N=4))

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -43,8 +43,8 @@ def build_experiments(N=2):
     Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
 
     # Build both samples
-    ML_flat = (Ni_layer, Si_layer)*N
-    ML_repeat = (Ni_layer | Si_layer)*N
+    ML_flat = (Ni_layer, Si_layer) * N
+    ML_repeat = (Ni_layer | Si_layer) * N
     ML_repeat.interface = Si_layer.interface
     sample_flat = Si_sub | ML_flat | air  # flat
     sample_repeat = Si_sub | ML_repeat | air  # repeat

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -21,13 +21,12 @@ def build_multilayer(N=2, flat=False):
     Si_ml = material.Material(formula="Si")
     air = material.Vacuum()
 
-
     # Single bilayer (Ni|Si)
     Ni_layer = layers.Slab(
         material=Ni,
         thickness=100,
         interface=5,
-        magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
+        magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T"),
     )
     Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
 
@@ -37,14 +36,15 @@ def build_multilayer(N=2, flat=False):
     Si_layer.interface.range(1, 20)
 
     if flat:
-        multilayer = (Ni_layer, Si_layer)*N
+        multilayer = (Ni_layer, Si_layer) * N
     else:
-        multilayer = (Ni_layer | Si_layer)*N
+        multilayer = (Ni_layer | Si_layer) * N
 
     # Substrate and repeat
     Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
 
     return Si_sub | multilayer | air
+
 
 def build_experiments(N=2):
     # Build both samples
@@ -68,6 +68,7 @@ def build_experiments(N=2):
     exp_repeat = Experiment(sample=sample_repeat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
     exp_flat = Experiment(sample=sample_flat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
     return exp_repeat, exp_flat
+
 
 def test_multilayer_equivalence(N=2):
     """Test that Repeat and flattened structures give identical results."""

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -1,0 +1,215 @@
+"""
+Test that Repeat and flattened multilayers produce identical results.
+
+Compares:
+1. A sample using Repeat(stack, N) with shared parameters across periods
+2. A sample with N independent copies of the stack (flattened)
+
+Both should produce identical reflectivity and profiles when parameters are matched.
+"""
+
+import numpy as np
+from refl1d.sample import material, layers, magnetism
+from refl1d.probe.probe import PolarizedNeutronProbe, NeutronProbe
+from refl1d.experiment import Experiment
+
+
+def build_repeat_multilayer(N=2):
+    """Build a multilayer using Repeat structure."""
+    Si = material.Material(formula="Si")
+    Ni = material.Material(formula="Ni[58]")
+    Si_ml = material.Material(formula="Si")
+    air = material.Vacuum()
+
+    # Single bilayer (Ni|Si)
+    Ni_layer = layers.Slab(
+        material=Ni,
+        thickness=100,
+        interface=5,
+    )
+    Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
+    bilayer = (
+        Ni_layer(
+            magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
+        )
+        | Si_layer
+    )
+
+    # Substrate and repeat
+    Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
+    ML = bilayer * N
+
+    return Si_sub | ML | air
+
+
+def build_flattened_multilayer(N=2):
+    """Build a multilayer by repeating layer objects N times."""
+    Si = material.Material(formula="Si")
+    Ni = material.Material(formula="Ni[58]")
+    Si_ml = material.Material(formula="Si")
+    air = material.Vacuum()
+
+    Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
+
+    # Build the stack by repeating the same layer objects
+    # (bumps will deduplicate by id, giving shared parameters)
+    Ni_layer = layers.Slab(
+        material=Ni,
+        thickness=100,
+        interface=5,
+    )
+    Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
+
+    bilayer = (
+        Ni_layer(
+            magnetism=magnetism.Magnetism(rhoM=2.0, interface_above=5.0, interface_below=5.0, name="Ni Layer 1.0T")
+        ),
+        Si_layer,
+    )
+    ML = bilayer * N
+
+    return Si_sub | ML | air
+
+
+def test_multilayer_equivalence(N=2):
+    """Test that Repeat and flattened structures give identical results."""
+    # Build both samples
+    sample_repeat = build_repeat_multilayer(N)
+    sample_flat = build_flattened_multilayer(N)
+
+    # Create T and L arrays
+    T = np.logspace(-3, 0, 50)
+    L = 5.0
+
+    # Create four NeutronProbe instances, one for each cross-section
+    probe_pp = NeutronProbe(T=T, L=L)
+    probe_pm = NeutronProbe(T=T, L=L)
+    probe_mp = NeutronProbe(T=T, L=L)
+    probe_mm = NeutronProbe(T=T, L=L)
+
+    # Create the polarized probe
+    probe = PolarizedNeutronProbe(pp=probe_pp, pm=probe_pm, mp=probe_mp, mm=probe_mm)
+
+    # Create experiments
+    exp_repeat = Experiment(sample=sample_repeat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
+    exp_flat = Experiment(sample=sample_flat, probe=probe, dz=0.5, step_interfaces=True, dA=None)
+
+    # Compare reflectivity
+    print(f"\n{'=' * 70}")
+    print(f"Testing magnetic multilayer: N={N} periods")
+    print(f"{'=' * 70}")
+
+    R_repeat = exp_repeat.reflectivity(resolution=False)
+    R_flat = exp_flat.reflectivity(resolution=False)
+
+    # PolarizedNeutronProbe returns 4 cross-sections: (Q, R_mm), (Q, R_mp), (Q, R_pm), (Q, R_pp)
+    Q_repeat, R_mm_repeat, R_mp_repeat, R_pm_repeat, R_pp_repeat = (
+        R_repeat[0][0],  # Q from first cross-section
+        R_repeat[0][1],  # R_mm
+        R_repeat[1][1],  # R_mp
+        R_repeat[2][1],  # R_pm
+        R_repeat[3][1],  # R_pp
+    )
+    Q_flat, R_mm_flat, R_mp_flat, R_pm_flat, R_pp_flat = (
+        R_flat[0][0],
+        R_flat[0][1],
+        R_flat[1][1],
+        R_flat[2][1],
+        R_flat[3][1],
+    )
+
+    # Check Q points match
+    assert np.allclose(Q_repeat, Q_flat), "Q points differ between Repeat and flattened"
+    print("✓ Q points match")
+
+    # Check reflectivity values match for all cross-sections
+    for label, R_r, R_f in [
+        ("mm", R_mm_repeat, R_mm_flat),
+        ("mp", R_mp_repeat, R_mp_flat),
+        ("pm", R_pm_repeat, R_pm_flat),
+        ("pp", R_pp_repeat, R_pp_flat),
+    ]:
+        R_diff = np.abs(R_r - R_f)
+        R_rel_err = R_diff / (np.abs(R_r) + 1e-10)
+        max_abs_err = np.max(R_diff)
+        max_rel_err = np.max(R_rel_err)
+
+        print(f"✓ Reflectivity {label} comparison:")
+        print(f"  Max absolute difference: {max_abs_err:.3e}")
+        print(f"  Max relative difference: {max_rel_err:.3e}")
+        assert max_abs_err < 1e-12, f"Reflectivity {label} differs: max error {max_abs_err}"
+    print("  ✓ All cross-section reflectivity values match")
+
+    # Compare magnetic slab profiles
+    w_r, sigma_r, rho_r, irho_r, rhoM_r, thetaM_r = exp_repeat.magnetic_slabs()
+    w_f, sigma_f, rho_f, irho_f, rhoM_f, thetaM_f = exp_flat.magnetic_slabs()
+
+    print(f"\n✓ Magnetic slab profile comparison:")
+    print(f"  Repeat:   {len(w_r)} slabs, thickness sum = {np.sum(w_r):.1f}")
+    print(f"  Flattened: {len(w_f)} slabs, thickness sum = {np.sum(w_f):.1f}")
+
+    # Check slab counts match
+    assert len(w_r) == len(w_f), f"Slab counts differ: {len(w_r)} vs {len(w_f)}"
+    print("  ✓ Slab counts match")
+
+    # Check thickness profiles match
+    assert np.allclose(w_r, w_f), "Thickness arrays differ"
+    assert np.allclose(sigma_r, sigma_f), "Sigma arrays differ"
+    print("  ✓ Thickness and roughness arrays match")
+
+    # Check rho profiles match
+    assert np.allclose(rho_r, rho_f), "Nuclear SLD arrays differ"
+    assert np.allclose(irho_r, irho_f), "Nuclear imaginary SLD arrays differ"
+    print("  ✓ Nuclear SLD arrays match")
+
+    # Check magnetic profiles match (with slight tolerance for sign/phase wrapping)
+    rhoM_diff = np.abs(rhoM_r - rhoM_f)
+    thetaM_diff = np.abs(thetaM_r - thetaM_f)
+    # Handle 360-degree wrapping in angle
+    thetaM_diff = np.minimum(thetaM_diff, 360 - thetaM_diff)
+
+    assert np.allclose(rhoM_diff, 0, atol=1e-10), f"Magnetic SLD differs: max {np.max(rhoM_diff)}"
+    assert np.allclose(thetaM_diff, 0, atol=1e-10), f"Magnetic angle differs: max {np.max(thetaM_diff)}"
+    print("  ✓ Magnetic SLD and angle arrays match")
+
+    # Print depth profile info
+    print(f"\n✓ Magnetic structure (first few slabs):")
+    for i in range(min(5, len(w_r))):
+        depth = np.sum(w_r[: i + 1])
+        print(
+            f"  Slab {i}: z={depth:.1f}, w={w_r[i]:.2f}, "
+            f"rho={rho_r[i]:.3f}, rhoM={rhoM_r[i]:.3f}, "
+            f"theta={thetaM_r[i]:.1f}°"
+        )
+    if len(w_r) > 5:
+        print(f"  ... ({len(w_r) - 5} more slabs)")
+
+    # Count magnetic slabs (nonzero rhoM)
+    mag_slabs_r = np.sum(np.abs(rhoM_r) > 1e-9)
+    mag_slabs_f = np.sum(np.abs(rhoM_f) > 1e-9)
+    print(f"\n✓ Magnetic slabs: {mag_slabs_r} (Repeat), {mag_slabs_f} (Flattened)")
+    assert mag_slabs_r == mag_slabs_f, "Number of magnetic slabs differs"
+
+    print(f"\n{'=' * 70}")
+    print(f"✓ ALL TESTS PASSED for N={N}")
+    print(f"{'=' * 70}\n")
+
+    return True
+
+
+if __name__ == "__main__":
+    # Test for different repeat counts
+    for N in [1, 2, 3, 10]:
+        try:
+            test_multilayer_equivalence(N)
+        except Exception as e:
+            print(f"\n✗ TEST FAILED for N={N}:")
+            print(f"  {type(e).__name__}: {e}")
+            import traceback
+
+            traceback.print_exc()
+            exit(1)
+
+    print("\n" + "=" * 70)
+    print("✓ ALL TESTS PASSED FOR ALL N VALUES")
+    print("=" * 70)

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -22,7 +22,8 @@ def build_experiments(N=2):
     Si_ml = material.Material(formula="Si")
     air = material.Vacuum()
 
-    # Single bilayer (Ni|Si)
+    # Substrate and bilayer layers
+    Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
     Ni_layer = layers.Slab(
         material=Ni,
         thickness=100,
@@ -31,23 +32,27 @@ def build_experiments(N=2):
     )
     Si_layer = layers.Slab(material=Si_ml, thickness=100, interface=5)
 
+    # Enable sliders in webview
     Si_ml.density.range(0, 10)
     Ni.density.range(0, 10)
-    Ni_layer.thickness.range(50, 200)
-    Ni_layer.interface.range(1, 20)
     Ni_layer.magnetism.rhoM.range(0, 5)
+    Ni_layer.thickness.range(50, 200)
     Si_layer.thickness.range(50, 200)
+    Si_sub.interface.range(1, 20)
+    Ni_layer.interface.range(1, 20)
     Si_layer.interface.range(1, 20)
 
-    # Substrate and repeat
-    Si_sub = layers.Slab(material=Si, thickness=0, interface=5)
-
-    # Build both samples
-    ML_flat = (Ni_layer, Si_layer) * N
-    ML_repeat = (Ni_layer | Si_layer) * N
+    # Build both samples. Note the difference in handling on the interface
+    # between the multilayer and the next layer. For (Ni|Si)*N it creates
+    # a Repeat structure which uses Si.interface between the repeats and
+    # Repeat.interface at the end. With (Ni, Si)*N it creates (Ni, Si, ..., Ni, Si)
+    # so the interface between the repeats is the same as the interface at the end.
+    # Setting Repeat.interface = Si.interface makes the two systems equivalent.
+    ML_flat = (Ni_layer, Si_layer) * N  # (Ni, Si, Ni, Si, ...)
+    ML_repeat = (Ni_layer | Si_layer) * N  # Repeat((Ni|Si), N)
     ML_repeat.interface = Si_layer.interface
-    sample_flat = Si_sub | ML_flat | air  # flat
-    sample_repeat = Si_sub | ML_repeat | air  # repeat
+    sample_flat = Si_sub | ML_flat | air
+    sample_repeat = Si_sub | ML_repeat | air
 
     # Create T and L arrays
     T = np.logspace(-3, 0, 50)
@@ -178,6 +183,17 @@ def test_multilayer_equivalence(N=2):
 # Make it so that we can load the model into refl1d and interact with the parameters.
 # The problem symbol is ignored when testing.
 problem = FitProblem(build_experiments(N=4))
+
+# Compare execution times between the two methods
+if False:
+    from timeit import timeit
+
+    repeats = 20
+    number = 10
+    exp_repeat, exp_flat = build_experiments(N=repeats)
+    t1 = timeit("exp_repeat.update(); exp_repeat.reflectivity()", globals=globals(), number=number)
+    t2 = timeit("exp_flat.update(); exp_flat.reflectivity()", globals=globals(), number=number)
+    print(f"time for N={repeats}: repeat={t1 / number:.4f}s, flat={t2 / number:.4f}s")
 
 if __name__ == "__main__":
     # Test for different repeat counts

--- a/tests/refl1d/test_magnetic_multilayer.py
+++ b/tests/refl1d/test_magnetic_multilayer.py
@@ -9,6 +9,7 @@ Both should produce identical reflectivity and profiles when parameters are matc
 """
 
 import numpy as np
+from bumps.names import FitProblem
 from refl1d.sample import material, layers, magnetism
 from refl1d.probe.probe import PolarizedNeutronProbe, NeutronProbe
 from refl1d.experiment import Experiment
@@ -33,6 +34,7 @@ def build_multilayer(N=2, flat=False):
 
     Ni_layer.thickness.range(50, 200)
     Ni_layer.interface.range(1, 20)
+    Ni_layer.magnetism.rhoM.range(0, 5)
     Si_layer.thickness.range(50, 200)
     Si_layer.interface.range(1, 20)
 
@@ -176,6 +178,10 @@ def test_multilayer_equivalence(N=2):
     return True
 
 
+# Make it so that we can load the model into refl1d and interact with the parameters.
+# The problem symbol is ignored when testing.
+problem = FitProblem(build_experiments(N=4))
+
 if __name__ == "__main__":
     # Test for different repeat counts
     for N in [2, 3, 10]:
@@ -193,8 +199,3 @@ if __name__ == "__main__":
     print("✓ ALL TESTS PASSED FOR ALL N VALUES")
     print("=" * 70)
 
-else:
-    # Allow loading into refl1d
-    from bumps.names import FitProblem
-
-    problem = FitProblem(build_experiments(N=4))


### PR DESCRIPTION
Addresses #339 

In this PR, special handling is added in the `Repeat.render()` method, so that if the stack is magnetic, it renders it `repeat` times sequentially, while still using the more optimized `slabs.repeat()` method for non-magnetic stacks.

It also fixes a small bug in identifying when a Stack is near the substrate, during `Stack._render_magnetic`, since `i==0` will be true at the start of any `Stack` enumeration, and not just the first one.  It is safer to check if any slabs have been created yet (`len(slabs) == 0`)

Adds a test which generates a multilayer Sample in two ways, e.g. 

- `Si | (Ni(magnetism=...), Si) * N | air`, which _doesn't_ create a Repeat class, vs. 
- `Si | (Ni(magnetism=...) | Si) * N | air` which _does_ create a `Repeat`, and which currently breaks because the `Repeat.render` method raises an exception if the stack is magnetic.

Then compares the profiles and reflectivities of the samples for the same `Probe`.

Model evaluation time is identical between the two methods.

There is a subtle difference between `(Ni|Si)*N -> Repeat(Ni|Si, N=N)` and `(Ni, Si)*N -> (Ni, Si, ..., Ni, Si)` in that the interface between the multilayer and the surround uses `Repeat.interface` in the first case and `Si.interface` in the second case.

Co-authored-by: Claude <noreply@anthropic.com>