### PR TITLE
turn on auto-tagging in Experiment

### DIFF
--- a/refl1d/deprecated/freeform.py
+++ b/refl1d/deprecated/freeform.py
@@ -179,7 +179,7 @@ class FreeInterface(Layer):
 
     def parameters(self):
         return {
-            "interface": self.interface.parameters(),
+            "interface": self.interface,
             "below": self.below.parameters(),
             "above": self.above.parameters(),
             "dz": self.dz,

--- a/refl1d/deprecated/freeform.py
+++ b/refl1d/deprecated/freeform.py
@@ -179,7 +179,7 @@ class FreeInterface(Layer):
 
     def parameters(self):
         return {
-            "interface": self.interface,
+            "interface": self.interface.parameters(),
             "below": self.below.parameters(),
             "above": self.above.parameters(),
             "dz": self.dz,

--- a/refl1d/experiment.py
+++ b/refl1d/experiment.py
@@ -37,7 +37,8 @@ from .utils import asbytes
 # We could do a version check, but the function is simple enough to reimplement
 def tag_all(pars, tag):
     for p in unique(pars):
-        p.add_tag(tag)
+        if hasattr(p, "add_tag"):
+            p.add_tag(tag)
 
 
 class WebviewPlotFunction(Protocol):

--- a/refl1d/experiment.py
+++ b/refl1d/experiment.py
@@ -18,7 +18,7 @@ import numpy as np
 from bumps import parameter
 from bumps.dream.state import MCMCDraw
 from bumps.fitproblem import Fitness, FitProblem
-from bumps.parameter import Parameter, tag_all
+from bumps.parameter import Parameter, unique  # CRUFT: should import tag_all instead of unique
 from refl1d.probe import ProbeSet
 
 from . import __version__
@@ -31,6 +31,13 @@ from . import profile
 from .probe.probe import PolarizedNeutronProbe, Probe, QProbe, PolarizedQProbe
 from .sample import layers, material
 from .utils import asbytes
+
+
+# CRUFT: tag_all is broken for bumps < 1.0.6
+# We could do a version check, but the function is simple enough to reimplement
+def tag_all(pars, tag):
+    for p in unique(pars):
+        p.add_tag(tag)
 
 
 class WebviewPlotFunction(Protocol):

--- a/refl1d/experiment.py
+++ b/refl1d/experiment.py
@@ -432,9 +432,7 @@ class Experiment(ExperimentBase):
         self.constraints = constraints
         self.version = __version__ if version is None else version
         if auto_tag:
-            probe_parameters = self.probe.parameters()
-            tag_all(probe_parameters, "instrument")
-            tag_all(probe_parameters, "nuisance")
+            tag_all(self.probe.parameters(), "instrument")
             if self.sample is not None:
                 tag_all(self.sample.parameters(), "sample")
         self._webview_plots = {}

--- a/refl1d/experiment.py
+++ b/refl1d/experiment.py
@@ -406,7 +406,7 @@ class Experiment(ExperimentBase):
         interpolation=0,
         constraints=None,
         version: Optional[str] = None,
-        auto_tag=False,
+        auto_tag=True,
     ):
         # Note: smoothness ignored
         self.sample = sample
@@ -432,8 +432,11 @@ class Experiment(ExperimentBase):
         self.constraints = constraints
         self.version = __version__ if version is None else version
         if auto_tag:
-            tag_all(self.probe.parameters(), "probe")
-            tag_all(self.sample.parameters(), "sample")
+            probe_parameters = self.probe.parameters()
+            tag_all(probe_parameters, "instrument")
+            tag_all(probe_parameters, "nuisance")
+            if self.sample is not None:
+                tag_all(self.sample.parameters(), "sample")
         self._webview_plots = {}
 
     @property


### PR DESCRIPTION
This PR 

- sets the default value of `auto_tag` in the Experiment initializer to `True`
- changes the first tag applied to `Probe` parameters from "probe" to "instrument"
- adds "nuisance" tag to `Probe` parameters