### PR TITLE
Qualify shared beam parameters with probe name for probeset and polarized

### DIFF
--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1287,7 +1287,9 @@ class ProbeSet:
                 yield p, (Q[offset : offset + n], R[offset : offset + n])
                 offset += n
 
-    def shared_beam(self, intensity=1, background=0, back_absorption=1, theta_offset=0, sample_broadening=0):
+    def shared_beam(
+        self, intensity=None, background=None, back_absorption=None, theta_offset=None, sample_broadening=None
+    ):
         """
         Share beam parameters across all segments.
 
@@ -1297,6 +1299,18 @@ class ProbeSet:
         with an explicit parameter in an individual segment if that
         parameter is independent.
         """
+        default_probe = self.probes[0]
+        if intensity is None:
+            intensity = default_probe.intensity
+        if background is None:
+            background = default_probe.background
+        if back_absorption is None:
+            back_absorption = default_probe.back_absorption
+        if theta_offset is None:
+            theta_offset = default_probe.theta_offset
+        if sample_broadening is None:
+            sample_broadening = default_probe.sample_broadening
+
         qualifier = f" {self.name}" if self.name else ""
         intensity = Parameter.default(intensity, name=f"intensity{qualifier}")
         background = Parameter.default(background, name=f"background{qualifier}", limits=[0, None])
@@ -1623,7 +1637,9 @@ class PolarizedNeutronProbe:
         else:
             raise ValueError("Cannot mix front and back reflectivity measurements")
 
-    def shared_beam(self, intensity=1, background=0, back_absorption=1, theta_offset=0, sample_broadening=0):
+    def shared_beam(
+        self, intensity=None, background=None, back_absorption=None, theta_offset=None, sample_broadening=None
+    ):
         """
         Share beam parameters across all four cross sections.
 
@@ -1633,6 +1649,20 @@ class PolarizedNeutronProbe:
         with an explicit parameter in an individual cross section if that
         parameter is independent.
         """
+        # Default parameters to the first non-empty cross section
+        # Note: this may be a non-spinflip channel if the mm cross section is missing.
+        default_probe = next(x for x in self.xs if x is not None)
+        if intensity is None:
+            intensity = default_probe.intensity
+        if background is None:
+            background = default_probe.background
+        if back_absorption is None:
+            back_absorption = default_probe.back_absorption
+        if theta_offset is None:
+            theta_offset = default_probe.theta_offset
+        if sample_broadening is None:
+            sample_broadening = default_probe.sample_broadening
+
         qualifier = f" {self.name}" if self.name else ""
         intensity = Parameter.default(intensity, name="intensity" + qualifier)
         background = Parameter.default(background, name="background" + qualifier, limits=[0, None])

--- a/refl1d/probe/probe.py
+++ b/refl1d/probe/probe.py
@@ -1297,11 +1297,14 @@ class ProbeSet:
         with an explicit parameter in an individual segment if that
         parameter is independent.
         """
-        intensity = Parameter.default(intensity, name="intensity")
-        background = Parameter.default(background, name="background", limits=[0, None])
-        back_absorption = Parameter.default(back_absorption, name="back_absorption", limits=[0, 1])
-        theta_offset = Parameter.default(theta_offset, name="theta_offset")
-        sample_broadening = Parameter.default(sample_broadening, name="sample_broadening", limits=[None, None])
+        qualifier = f" {self.name}" if self.name else ""
+        intensity = Parameter.default(intensity, name=f"intensity{qualifier}")
+        background = Parameter.default(background, name=f"background{qualifier}", limits=[0, None])
+        back_absorption = Parameter.default(back_absorption, name=f"back_absorption{qualifier}", limits=[0, 1])
+        theta_offset = Parameter.default(theta_offset, name=f"theta_offset{qualifier}")
+        sample_broadening = Parameter.default(
+            sample_broadening, name=f"sample_broadening{qualifier}", limits=[None, None]
+        )
         for p in self.probes:
             p.intensity = intensity
             p.background = background
@@ -1630,11 +1633,14 @@ class PolarizedNeutronProbe:
         with an explicit parameter in an individual cross section if that
         parameter is independent.
         """
-        intensity = Parameter.default(intensity, name="intensity")
-        background = Parameter.default(background, name="background", limits=[0, None])
-        back_absorption = Parameter.default(back_absorption, name="back_absorption", limits=[0, 1])
-        theta_offset = Parameter.default(theta_offset, name="theta_offset")
-        sample_broadening = Parameter.default(sample_broadening, name="sample_broadening", limits=[None, None])
+        qualifier = f" {self.name}" if self.name else ""
+        intensity = Parameter.default(intensity, name="intensity" + qualifier)
+        background = Parameter.default(background, name="background" + qualifier, limits=[0, None])
+        back_absorption = Parameter.default(back_absorption, name="back_absorption" + qualifier, limits=[0, 1])
+        theta_offset = Parameter.default(theta_offset, name="theta_offset" + qualifier)
+        sample_broadening = Parameter.default(
+            sample_broadening, name="sample_broadening" + qualifier, limits=[None, None]
+        )
         for x in self.xs:
             if x is not None:
                 x.intensity = intensity


### PR DESCRIPTION
Automatically tags the parameter name with the probe name for shared beam parameters.

For non-shared polarized probes, the beam parameters are not being tagged with cross section. This PR does not address this.

We now share the beam parameters from the first probe rather than creating new parameters. This will only apply to parameters not explicitly listed in the `shared_beam` call.

Any initial guesses such as `background=1e-6` or `theta_offset=0.01` that were given when the first probe was loaded will propagate to all the other probes. For the polref loader (#382), that means `theta_offset` etc. specified in the `load_probe_polref` call will be respected in the shared beam, without needing a separate `probe.shared_beam(theta_offset=...)` after loading.

The parameters will still be qualified with the name from the first probe. That's a little ugly if the probes have unique names (cross section or sequence number for example). If that's a problem we can copy it and give it a new name.

---

Things to consider:

* We can use `parameter.equals(shared)` rather than `parameter=shared` to constrain them. That way we can unlink them to stop sharing. If they are shared by assignment, we would need to make a copy of the parameter to stop sharing. The two parameters will share the same name, which will be confusing.
