### PR TITLE
Use correct load_problem interface when analyzing oversampling

### DIFF
--- a/refl1d/probe/oversampling.py
+++ b/refl1d/probe/oversampling.py
@@ -161,7 +161,7 @@ def main():
 
     opts = parser.parse_args(None if sys.argv[1:] else ["-h"])
 
-    problem = load_problem(opts.modelfile[0], model_options=opts.modelopts)
+    problem = load_problem(opts.modelfile[0], args=opts.modelopts)
     if opts.pars:
         load_pars(problem, opts.pars)
 


### PR DESCRIPTION
When switching from old `cli.load_model(path, model_options=...)` to new `fitproblem.load_problem(path, args=...)` we changed the function name in the call but not the argument name. As a result, `python -m refl1d.probe.oversampling` no longer works.